### PR TITLE
Minor amend - Changing references to the module name to prevent confusion

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ the tag that corresponds to your version for the correct documentation.
 
     ```hcl
     module "vault" {
-      source         = "GoogleCloudPlatform/vault/google"
+      source         = "terraform-google-modules/vault/google"
       project_id     = "${var.project_id}"
       region         = "${var.region}"
       kms_keyring    = "${var.kms_keyring}"

--- a/examples/vault-on-gce/main.tf
+++ b/examples/vault-on-gce/main.tf
@@ -44,7 +44,7 @@ variable kms_crypto_key {
 }
 
 module "vault" {
-  // source = "GoogleCloudPlatform/vault/google"
+  // source = "terraform-google-modules/vault/google"
 
   source     = "../../"
   project_id = "${var.project_id}"


### PR DESCRIPTION

Following the documentation and example you may end up with terraform being unable to identify the module, as they points to a repo name not matching terraform modules registry. Aligning that to [this](https://registry.terraform.io/modules/terraform-google-modules/vault/google/2.0.1)