### PR TITLE
GCS versioning as an option

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,3 @@
+.terraform/
+examples/
+README.md

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,8 @@
+FROM hashicorp/terraform:0.11.14
+RUN apk --no-cache add bash && rm -rf /var/cache/apk/*
+
+WORKDIR /project
+ADD . .
+RUN terraform init
+RUN terraform validate -var-file=tests.tfvars
+RUN terraform fmt -check=true -diff=true

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,5 @@
-FROM hashicorp/terraform:0.11.14
+ARG tf_version=0.11.14
+FROM hashicorp/terraform:${tf_version}
 RUN apk --no-cache add bash && rm -rf /var/cache/apk/*
 
 WORKDIR /project

--- a/README.md
+++ b/README.md
@@ -212,3 +212,11 @@ Instance" tagged as "vaultproject.io/audit".
 [registry-inputs]: https://registry.terraform.io/modules/terraform-google-modules/vault/google?tab=inputs
 [registry-outputs]: https://registry.terraform.io/modules/terraform-google-modules/vault/google?tab=outputs
 [registry-resources]: https://registry.terraform.io/modules/terraform-google-modules/vault/google?tab=resources
+
+## Terraform module development
+
+If you want to execute basic terraform validation/linting tests, you can just issue:
+
+```bash
+$ docker build .
+```

--- a/README.md
+++ b/README.md
@@ -220,3 +220,32 @@ If you want to execute basic terraform validation/linting tests, you can just is
 ```bash
 $ docker build .
 ```
+
+*NOTE: This module is still not compatible with Terraform 0.12. See:*
+
+```bash
+$ docker build . --build-arg tf_version=0.12.3
+Sending build context to Docker daemon  588.8kB
+Step 1/8 : ARG tf_version=0.11.14
+Step 2/8 : FROM hashicorp/terraform:${tf_version}
+0.12.3: Pulling from hashicorp/terraform
+...
+Error: Invalid default value for variable
+                              
+  on variables.tf line 245, in variable "tls_ca_subject":   
+ 245:   default = {                                                        
+ 246:     common_name         = "Example Inc. Root"
+ 247:     organization        = "Example, Inc"
+ 248:     organizational_unit = "Department of Certificate Authority"
+ 249:     street_address      = ["123 Example Street"]           
+ 250:     locality            = "The Intranet"                                                                     
+ 251:     province            = "CA"           
+ 252:     country             = "US"           
+ 253:     postal_code         = "95559-1227"
+ 254:   }                                        
+                                        
+This default value is not compatible with the variable's type constraint: all  
+map elements must have the same type.                        
+                  
+The command '/bin/sh -c terraform validate -var-file=tests.tfvars' returned a non-zero code: 1
+```

--- a/main.tf
+++ b/main.tf
@@ -15,8 +15,6 @@
 #
 
 locals {
-  # Allow the user to specify a custom bucket name, default to project-id prefix
-  storage_bucket_name = "${var.storage_bucket_name != "" ? var.storage_bucket_name : "${var.project_id}-vault-data"}"
   vault_tls_bucket    = "${var.vault_tls_bucket != "" ? var.vault_tls_bucket : local.storage_bucket_name}"
 
   # Inverts logic from user perspective to terraform perspective for use in count
@@ -42,23 +40,6 @@ resource "google_project_service" "service" {
   disable_on_destroy = false
 }
 
-# Create the storage bucket for where Vault data will be stored. This is a
-# multi-regional storage bucket so it has the highest level of availability.
-resource "google_storage_bucket" "vault" {
-  project = "${var.project_id}"
-
-  name          = "${local.storage_bucket_name}"
-  location      = "${upper(var.storage_bucket_location)}"
-  storage_class = "MULTI_REGIONAL"
-
-  versioning {
-    enabled = "${var.storage_versioning}"
-  }
-
-  force_destroy = "${var.storage_bucket_force_destroy}"
-
-  depends_on = ["google_project_service.service"]
-}
 
 # Create the vault-admin service account.
 resource "google_service_account" "vault-admin" {

--- a/main.tf
+++ b/main.tf
@@ -14,6 +14,10 @@
 # limitations under the License.
 #
 
+terraform {
+  required_version = "~> 0.11.10"
+}
+
 locals {
   vault_tls_bucket = "${var.vault_tls_bucket != "" ? var.vault_tls_bucket : local.storage_bucket_name}"
 

--- a/main.tf
+++ b/main.tf
@@ -50,6 +50,11 @@ resource "google_storage_bucket" "vault" {
   name          = "${local.storage_bucket_name}"
   location      = "${upper(var.storage_bucket_location)}"
   storage_class = "MULTI_REGIONAL"
+
+  versioning {
+    enabled = "${var.storage_versioning}"
+  }
+
   force_destroy = "${var.storage_bucket_force_destroy}"
 
   depends_on = ["google_project_service.service"]

--- a/main.tf
+++ b/main.tf
@@ -15,7 +15,7 @@
 #
 
 locals {
-  vault_tls_bucket    = "${var.vault_tls_bucket != "" ? var.vault_tls_bucket : local.storage_bucket_name}"
+  vault_tls_bucket = "${var.vault_tls_bucket != "" ? var.vault_tls_bucket : local.storage_bucket_name}"
 
   # Inverts logic from user perspective to terraform perspective for use in count
   manage_tls = "${var.manage_tls == "true" ? 1 : 0}"
@@ -39,7 +39,6 @@ resource "google_project_service" "service" {
   # we might not "own" the services we enable.
   disable_on_destroy = false
 }
-
 
 # Create the vault-admin service account.
 resource "google_service_account" "vault-admin" {

--- a/storage.tf
+++ b/storage.tf
@@ -1,0 +1,22 @@
+locals {
+  # Allow the user to specify a custom bucket name, default to project-id prefix
+  storage_bucket_name = "${var.storage_bucket_name != "" ? var.storage_bucket_name : "${var.project_id}-vault-data"}"
+}
+
+# Create the storage bucket for where Vault data will be stored. This is a
+# multi-regional storage bucket so it has the highest level of availability.
+resource "google_storage_bucket" "vault" {
+  project = "${var.project_id}"
+
+  name          = "${local.storage_bucket_name}"
+  location      = "${upper(var.storage_bucket_location)}"
+  storage_class = "MULTI_REGIONAL"
+
+  versioning {
+    enabled = "${var.storage_versioning}"
+  }
+
+  force_destroy = "${var.storage_bucket_force_destroy}"
+
+  depends_on = ["google_project_service.service"]
+}

--- a/storage.tf
+++ b/storage.tf
@@ -16,7 +16,7 @@ resource "google_storage_bucket" "vault" {
     enabled = "${var.storage_versioning}"
   }
 
-  lifecycle_rule = "${var.storage_lifecycle_rule}"
+  lifecycle_rule = "${var.storage_lifecycle_rules}"
 
   force_destroy = "${var.storage_bucket_force_destroy}"
 

--- a/storage.tf
+++ b/storage.tf
@@ -16,6 +16,8 @@ resource "google_storage_bucket" "vault" {
     enabled = "${var.storage_versioning}"
   }
 
+  lifecycle_rule = "${var.storage_lifecycle_rule}"
+
   force_destroy = "${var.storage_bucket_force_destroy}"
 
   depends_on = ["google_project_service.service"]

--- a/tests.tfvars
+++ b/tests.tfvars
@@ -1,0 +1,5 @@
+# Just required ones
+
+project_id = "gcp-demo-project"
+
+kms_keyring = "gcp-demo-keyring"

--- a/tests.tfvars
+++ b/tests.tfvars
@@ -3,3 +3,13 @@
 project_id = "gcp-demo-project"
 
 kms_keyring = "gcp-demo-keyring"
+
+storage_lifecycle_rules = [{
+  action = [{
+      type = "Delete"
+  }]
+  condition = [{
+      age = 60
+      with_state = "ARCHIVED"
+  }]
+}]

--- a/variables.tf
+++ b/variables.tf
@@ -87,6 +87,15 @@ will be stored. Valid values include:
 EOF
 }
 
+variable storage_versioning {
+  type    = "string"
+  default = false
+
+  description = <<EOF
+Set to true to enable versioning.
+EOF
+}
+
 variable storage_bucket_force_destroy {
   type    = "string"
   default = false

--- a/variables.tf
+++ b/variables.tf
@@ -96,7 +96,7 @@ Set to true to enable versioning.
 EOF
 }
 
-variable storage_lifecycle_rule {
+variable storage_lifecycle_rules {
   type    = "list"
   default = []
 

--- a/variables.tf
+++ b/variables.tf
@@ -96,6 +96,17 @@ Set to true to enable versioning.
 EOF
 }
 
+variable storage_lifecycle_rule {
+  type    = "list"
+  default = []
+
+  description = <<EOF
+If you enable versioning, you may want to expire old versions to configure
+a specific retention. Please, check the documentation for the map keys you
+should use.
+EOF
+}
+
 variable storage_bucket_force_destroy {
   type    = "string"
   default = false


### PR DESCRIPTION
Hi!!

  in order to have the option to increase the storage resiliency still more, I think giving the option of enable bucket versioning would be great! I keep it disabled by default, as we used to have, but you can override that with a variable. 

  Note: versioning, by itself, is not super-useful: given how HCV stores the data, doing point in time recovery can be time consuming (going trough tens of objects and looking the convenient version to restore, keeping the bucket consistent), while I'm not sure just restoring individual objects is acceptable (may make the storage-backend inconsistent)... but with the usage of a tool like [this](https://github.com/madisoft/s3-pit-restore) (we are working in something equivalent, but for GCS), and considering you were already promoting multiregion bucket, data resiliency / most of the backup-recovery scenarios are covered by default.
