### PR TITLE
Feature #Update: Terraform Version v0.12.2

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -16,26 +16,26 @@
 
 locals {
   # Allow the user to specify a custom bucket name, default to project-id prefix
-  storage_bucket_name = "${var.storage_bucket_name != "" ? var.storage_bucket_name : "${var.project_id}-vault-data"}"
-  vault_tls_bucket    = "${var.vault_tls_bucket != "" ? var.vault_tls_bucket : local.storage_bucket_name}"
+  storage_bucket_name = var.storage_bucket_name != "" ? var.storage_bucket_name : "${var.project_id}-vault-data"
+  vault_tls_bucket    = var.vault_tls_bucket != "" ? var.vault_tls_bucket : local.storage_bucket_name
 
   # Inverts logic from user perspective to terraform perspective for use in count
-  manage_tls = "${var.manage_tls == "true" ? 1 : 0}"
+  manage_tls = var.manage_tls == "true" ? 1 : 0
 }
 
 # Configure the Google provider, locking to the 2.0 series.
 provider "google" {
   version = "~> 2.0"
-  project = "${var.project_id}"
-  region  = "${var.region}"
+  project = var.project_id
+  region  = var.region
 }
 
 # Enable required services on the project
 resource "google_project_service" "service" {
-  count   = "${length(var.project_services)}"
-  project = "${var.project_id}"
+  count   = length(var.project_services)
+  project = var.project_id
 
-  service = "${element(var.project_services, count.index)}"
+  service = element(var.project_services, count.index)
 
   # Do not disable the service on destroy. This may be a shared project, and
   # we might not "own" the services we enable.
@@ -45,126 +45,125 @@ resource "google_project_service" "service" {
 # Create the storage bucket for where Vault data will be stored. This is a
 # multi-regional storage bucket so it has the highest level of availability.
 resource "google_storage_bucket" "vault" {
-  project = "${var.project_id}"
+  project = var.project_id
 
-  name          = "${local.storage_bucket_name}"
-  location      = "${upper(var.storage_bucket_location)}"
+  name          = local.storage_bucket_name
+  location      = upper(var.storage_bucket_location)
   storage_class = "MULTI_REGIONAL"
-  force_destroy = "${var.storage_bucket_force_destroy}"
+  force_destroy = var.storage_bucket_force_destroy
 
-  depends_on = ["google_project_service.service"]
+  depends_on = [google_project_service.service]
 }
 
 # Create the vault-admin service account.
 resource "google_service_account" "vault-admin" {
-  account_id   = "${var.service_account_name}"
+  account_id   = var.service_account_name
   display_name = "Vault Admin"
 
-  depends_on = ["google_project_service.service"]
+  depends_on = [google_project_service.service]
 }
 
 # Give project-level IAM permissions to the service account.
 resource "google_project_iam_member" "project-iam" {
-  count   = "${length(var.service_account_project_iam_roles)}"
-  project = "${var.project_id}"
-  role    = "${element(var.service_account_project_iam_roles, count.index)}"
+  count   = length(var.service_account_project_iam_roles)
+  project = var.project_id
+  role    = element(var.service_account_project_iam_roles, count.index)
   member  = "serviceAccount:${google_service_account.vault-admin.email}"
 
-  depends_on = ["google_project_service.service"]
+  depends_on = [google_project_service.service]
 }
 
 # Give additional project-level IAM permissions to the service account.
 resource "google_project_iam_member" "additional-project-iam" {
-  count   = "${length(var.service_account_project_additional_iam_roles)}"
-  project = "${var.project_id}"
-  role    = "${element(var.service_account_project_additional_iam_roles, count.index)}"
-  member  = "serviceAccount:${google_service_account.vault-admin.email}"
+  count   = length(var.service_account_project_additional_iam_roles)
+  project = var.project_id
+  role = element(
+    var.service_account_project_additional_iam_roles,
+    count.index,
+  )
+  member = "serviceAccount:${google_service_account.vault-admin.email}"
 
-  depends_on = ["google_project_service.service"]
+  depends_on = [google_project_service.service]
 }
 
 # Give bucket-level permissions to the service account.
 resource "google_storage_bucket_iam_member" "vault" {
-  count  = "${length(var.service_account_storage_bucket_iam_roles)}"
-  bucket = "${google_storage_bucket.vault.name}"
-  role   = "${element(var.service_account_storage_bucket_iam_roles, count.index)}"
+  count  = length(var.service_account_storage_bucket_iam_roles)
+  bucket = google_storage_bucket.vault.name
+  role   = element(var.service_account_storage_bucket_iam_roles, count.index)
   member = "serviceAccount:${google_service_account.vault-admin.email}"
 
-  depends_on = ["google_project_service.service"]
+  depends_on = [google_project_service.service]
 }
 
 # Give kms cryptokey-level permissions to the service account.
 resource "google_kms_crypto_key_iam_member" "ck-iam" {
-  crypto_key_id = "${google_kms_crypto_key.vault-init.self_link}"
+  crypto_key_id = google_kms_crypto_key.vault-init.self_link
   role          = "roles/cloudkms.cryptoKeyEncrypterDecrypter"
   member        = "serviceAccount:${google_service_account.vault-admin.email}"
 
-  depends_on = ["google_project_service.service"]
+  depends_on = [google_project_service.service]
 }
 
 # Create the KMS key ring
 resource "google_kms_key_ring" "vault" {
-  name     = "${var.kms_keyring}"
-  location = "${var.region}"
-  project  = "${var.project_id}"
+  name     = var.kms_keyring
+  location = var.region
+  project  = var.project_id
 
-  depends_on = ["google_project_service.service"]
+  depends_on = [google_project_service.service]
 }
 
 # Create the crypto key for encrypting init keys
 resource "google_kms_crypto_key" "vault-init" {
-  name            = "${var.kms_crypto_key}"
-  key_ring        = "${google_kms_key_ring.vault.id}"
+  name            = var.kms_crypto_key
+  key_ring        = google_kms_key_ring.vault.id
   rotation_period = "604800s"
 
   version_template {
     algorithm        = "GOOGLE_SYMMETRIC_ENCRYPTION"
-    protection_level = "${upper(var.kms_protection_level)}"
+    protection_level = upper(var.kms_protection_level)
   }
 }
 
 # Compile the startup script. This script installs and configures Vault and all
 # dependencies.
 data "template_file" "vault-startup-script" {
-  template = "${file("${path.module}/scripts/startup.sh.tpl")}"
+  template = file("${path.module}/scripts/startup.sh.tpl")
 
-  vars {
-    config                = "${data.template_file.vault-config.rendered}"
-    service_account_email = "${google_service_account.vault-admin.email}"
-
-    vault_args       = "${var.vault_args}"
-    vault_port       = "${var.vault_port}"
-    vault_proxy_port = "${var.vault_proxy_port}"
-    vault_version    = "${var.vault_version}"
-
-    vault_tls_bucket        = "${local.vault_tls_bucket}"
-    vault_ca_cert_filename  = "${var.vault_ca_cert_filename}"
-    vault_tls_key_filename  = "${var.vault_tls_key_filename}"
-    vault_tls_cert_filename = "${var.vault_tls_cert_filename}"
-
-    kms_project    = "${var.project_id}"
-    kms_location   = "${google_kms_key_ring.vault.location}"
-    kms_keyring    = "${google_kms_key_ring.vault.name}"
-    kms_crypto_key = "${google_kms_crypto_key.vault-init.name}"
+  vars = {
+    config                  = data.template_file.vault-config.rendered
+    service_account_email   = google_service_account.vault-admin.email
+    vault_args              = var.vault_args
+    vault_port              = var.vault_port
+    vault_proxy_port        = var.vault_proxy_port
+    vault_version           = var.vault_version
+    vault_tls_bucket        = local.vault_tls_bucket
+    vault_ca_cert_filename  = var.vault_ca_cert_filename
+    vault_tls_key_filename  = var.vault_tls_key_filename
+    vault_tls_cert_filename = var.vault_tls_cert_filename
+    kms_project             = var.project_id
+    kms_location            = google_kms_key_ring.vault.location
+    kms_keyring             = google_kms_key_ring.vault.name
+    kms_crypto_key          = google_kms_crypto_key.vault-init.name
   }
 }
 
 # Compile the Vault configuration.
 data "template_file" "vault-config" {
-  template = "${file("${format("%s/scripts/config.hcl.tpl", path.module)}")}"
+  template = file(format("%s/scripts/config.hcl.tpl", path.module))
 
-  vars {
-    kms_project    = "${var.project_id}"
-    kms_location   = "${google_kms_key_ring.vault.location}"
-    kms_keyring    = "${google_kms_key_ring.vault.name}"
-    kms_crypto_key = "${google_kms_crypto_key.vault-init.name}"
-
-    lb_ip          = "${google_compute_address.vault.address}"
-    storage_bucket = "${google_storage_bucket.vault.name}"
-
-    vault_log_level                = "${var.vault_log_level}"
-    vault_port                     = "${var.vault_port}"
-    vault_tls_disable_client_certs = "${var.vault_tls_disable_client_certs}"
-    vault_ui_enabled               = "${var.vault_ui_enabled}"
+  vars = {
+    kms_project                    = var.project_id
+    kms_location                   = google_kms_key_ring.vault.location
+    kms_keyring                    = google_kms_key_ring.vault.name
+    kms_crypto_key                 = google_kms_crypto_key.vault-init.name
+    lb_ip                          = google_compute_address.vault.address
+    storage_bucket                 = google_storage_bucket.vault.name
+    vault_log_level                = var.vault_log_level
+    vault_port                     = var.vault_port
+    vault_tls_disable_client_certs = var.vault_tls_disable_client_certs
+    vault_ui_enabled               = var.vault_ui_enabled
   }
 }
+

--- a/network.tf
+++ b/network.tf
@@ -21,75 +21,75 @@
 # Address for NATing
 resource "google_compute_address" "vault-nat" {
   count   = 2
-  project = "${var.project_id}"
+  project = var.project_id
   name    = "vault-nat-external-${count.index}"
-  region  = "${var.region}"
+  region  = var.region
 
-  depends_on = ["google_project_service.service"]
+  depends_on = [google_project_service.service]
 }
 
 # Create a NAT router so the nodes can reach the public Internet
 resource "google_compute_router" "vault-router" {
   name    = "vault-router"
-  project = "${var.project_id}"
-  region  = "${var.region}"
-  network = "${google_compute_network.vault-network.self_link}"
+  project = var.project_id
+  region  = var.region
+  network = google_compute_network.vault-network.self_link
 
   bgp {
     asn = 64514
   }
 
-  depends_on = ["google_project_service.service"]
+  depends_on = [google_project_service.service]
 }
 
 # NAT on the main subnetwork
 resource "google_compute_router_nat" "vault-nat" {
   name    = "vault-nat-1"
-  project = "${var.project_id}"
-  router  = "${google_compute_router.vault-router.name}"
-  region  = "${var.region}"
+  project = var.project_id
+  router  = google_compute_router.vault-router.name
+  region  = var.region
 
   nat_ip_allocate_option = "MANUAL_ONLY"
-  nat_ips                = ["${google_compute_address.vault-nat.*.self_link}"]
+  nat_ips                = google_compute_address.vault-nat.*.self_link
 
   source_subnetwork_ip_ranges_to_nat = "LIST_OF_SUBNETWORKS"
 
   subnetwork {
-    name                    = "${google_compute_subnetwork.vault-subnet.self_link}"
+    name                    = google_compute_subnetwork.vault-subnet.self_link
     source_ip_ranges_to_nat = ["PRIMARY_IP_RANGE"]
   }
 
-  depends_on = ["google_project_service.service"]
+  depends_on = [google_project_service.service]
 }
 
 resource "google_compute_network" "vault-network" {
-  project = "${var.project_id}"
+  project = var.project_id
 
   name                    = "vault-network"
   auto_create_subnetworks = false
 
-  depends_on = ["google_project_service.service"]
+  depends_on = [google_project_service.service]
 }
 
 resource "google_compute_subnetwork" "vault-subnet" {
-  project = "${var.project_id}"
+  project = var.project_id
 
   name                     = "vault-subnet"
-  region                   = "${var.region}"
-  ip_cidr_range            = "${var.network_subnet_cidr_range}"
-  network                  = "${google_compute_network.vault-network.self_link}"
+  region                   = var.region
+  ip_cidr_range            = var.network_subnet_cidr_range
+  network                  = google_compute_network.vault-network.self_link
   private_ip_google_access = true
 
-  depends_on = ["google_project_service.service"]
+  depends_on = [google_project_service.service]
 }
 
 resource "google_compute_address" "vault" {
-  project = "${var.project_id}"
+  project = var.project_id
 
   name   = "vault-lb"
-  region = "${var.region}"
+  region = var.region
 
-  depends_on = ["google_project_service.service"]
+  depends_on = [google_project_service.service]
 }
 
 # Data source for list of google IPs
@@ -101,74 +101,73 @@ data "google_compute_lb_ip_ranges" "ranges" {
 # legacy proxied health port over HTTP because the health checks do not support
 # HTTPS.
 resource "google_compute_firewall" "allow-lb-healthcheck" {
-  project = "${var.project_id}"
+  project = var.project_id
   name    = "vault-allow-lb-healthcheck"
-  network = "${google_compute_network.vault-network.self_link}"
+  network = google_compute_network.vault-network.self_link
 
   allow {
     protocol = "tcp"
-    ports    = ["${var.vault_proxy_port}"]
+    ports    = [var.vault_proxy_port]
   }
 
-  source_ranges = [
-    "${data.google_compute_lb_ip_ranges.ranges.network}",
-    "${data.google_compute_lb_ip_ranges.ranges.http_ssl_tcp_internal}",
-  ]
+  source_ranges = flatten([
+    data.google_compute_lb_ip_ranges.ranges.network,
+    data.google_compute_lb_ip_ranges.ranges.http_ssl_tcp_internal,
+  ])
 
   target_tags = ["allow-vault"]
 
-  depends_on = ["google_project_service.service"]
+  depends_on = [google_project_service.service]
 }
 
 # Allow any user-defined CIDRs to talk to the Vault instances.
 resource "google_compute_firewall" "allow-external" {
-  project = "${var.project_id}"
+  project = var.project_id
   name    = "vault-allow-external"
-  network = "${google_compute_network.vault-network.self_link}"
+  network = google_compute_network.vault-network.self_link
 
   allow {
     protocol = "tcp"
-    ports    = ["${var.vault_port}"]
+    ports    = [var.vault_port]
   }
 
-  source_ranges = [
-    "${var.vault_allowed_cidrs}",
-  ]
+  source_ranges = var.vault_allowed_cidrs
 
   target_tags = ["allow-vault"]
 
-  depends_on = ["google_project_service.service"]
+  depends_on = [google_project_service.service]
 }
 
 # Allow Vault nodes to talk internally on the Vault ports.
 resource "google_compute_firewall" "allow-internal" {
-  project = "${var.project_id}"
+  project = var.project_id
   name    = "vault-allow-internal"
-  network = "${google_compute_network.vault-network.self_link}"
+  network = google_compute_network.vault-network.self_link
 
   allow {
     protocol = "tcp"
     ports    = ["${var.vault_port}-${var.vault_port + 1}"]
   }
 
-  source_ranges = ["${google_compute_subnetwork.vault-subnet.ip_cidr_range}"]
+  source_ranges = [google_compute_subnetwork.vault-subnet.ip_cidr_range]
 
-  depends_on = ["google_project_service.service"]
+  depends_on = [google_project_service.service]
 }
 
 # Allow SSHing into machines tagged "allow-ssh"
 resource "google_compute_firewall" "allow-ssh" {
-  project = "${var.project_id}"
+  project = var.project_id
   name    = "vault-allow-ssh"
-  network = "${google_compute_network.vault-network.self_link}"
+  network = google_compute_network.vault-network.self_link
 
   allow {
     protocol = "tcp"
     ports    = ["22"]
   }
 
-  source_ranges = ["${var.ssh_allowed_cidrs}"]
+  source_ranges = var.ssh_allowed_cidrs
   target_tags   = ["allow-ssh"]
 
-  depends_on = ["google_project_service.service"]
+  depends_on = [google_project_service.service]
 }
+

--- a/outputs.tf
+++ b/outputs.tf
@@ -14,36 +14,39 @@
 # limitations under the License.
 #
 
-output ca_cert_pem {
-  value     = "${tls_self_signed_cert.root.*.cert_pem}"
+output "ca_cert_pem" {
+  value     = tls_self_signed_cert.root.*.cert_pem
   sensitive = true
 
   description = <<EOF
 CA certificate used to verify Vault TLS client connections.
 EOF
+
 }
 
-output ca_key_pem {
-  value     = "${tls_private_key.root.*.private_key_pem}"
+output "ca_key_pem" {
+  value = tls_private_key.root.*.private_key_pem
   sensitive = true
 
   description = <<EOF
 Private key for the CA.
 EOF
+
 }
 
-output service_account_email {
-  value = "${google_service_account.vault-admin.email}"
+output "service_account_email" {
+value = google_service_account.vault-admin.email
 
-  description = <<EOF
+description = <<EOF
 Email for the vault-admin service account.
 EOF
+
 }
 
-output vault_addr {
-  value = "https://${google_compute_address.vault.address}:${var.vault_port}"
+output "vault_addr" {
+value = "https://${google_compute_address.vault.address}:${var.vault_port}"
 
-  description = <<EOF
+description = <<EOF
 Full protocol, address, and port (FQDN) pointing to the Vault load balancer.
 This is a drop-in to VAULT_ADDR:
 
@@ -51,21 +54,25 @@ This is a drop-in to VAULT_ADDR:
 
 And then continue to use Vault commands as usual.
 EOF
+
 }
 
-output vault_lb_addr {
-  value = "${google_compute_address.vault.address}"
+output "vault_lb_addr" {
+  value = google_compute_address.vault.address
 
   description = <<EOF
 Address of the load balancer without port or protocol information. You probably
 want to use `vault_addr`.
 EOF
+
 }
 
-output vault_lb_port {
-  value = "${var.vault_port}"
+output "vault_lb_port" {
+  value = var.vault_port
 
   description = <<EOF
 Port where Vault is exposed on the load balancer.
 EOF
+
 }
+

--- a/tls.tf
+++ b/tls.tf
@@ -21,7 +21,7 @@
 
 # Generate a self-sign TLS certificate that will act as the root CA.
 resource "tls_private_key" "root" {
-  count = "${local.manage_tls}"
+  count = local.manage_tls
 
   algorithm = "RSA"
   rsa_bits  = "2048"
@@ -29,12 +29,25 @@ resource "tls_private_key" "root" {
 
 # Sign ourselves
 resource "tls_self_signed_cert" "root" {
-  count = "${local.manage_tls}"
+  count = local.manage_tls
 
-  key_algorithm   = "${tls_private_key.root.algorithm}"
-  private_key_pem = "${tls_private_key.root.private_key_pem}"
+  key_algorithm   = tls_private_key.root[0].algorithm
+  private_key_pem = tls_private_key.root[0].private_key_pem
 
-  subject = ["${var.tls_ca_subject}"]
+  dynamic "subject" {
+    for_each = [var.tls_ca_subject]
+    content {
+      common_name         = lookup(subject.value, "common_name", null)
+      country             = lookup(subject.value, "country", null)
+      locality            = lookup(subject.value, "locality", null)
+      organization        = lookup(subject.value, "organization", null)
+      organizational_unit = lookup(subject.value, "organizational_unit", null)
+      postal_code         = lookup(subject.value, "postal_code", null)
+      province            = lookup(subject.value, "province", null)
+      serial_number       = lookup(subject.value, "serial_number", null)
+      street_address      = lookup(subject.value, "street_address", null)
+    }
+  }
 
   validity_period_hours = 26280
   early_renewal_hours   = 8760
@@ -45,15 +58,15 @@ resource "tls_self_signed_cert" "root" {
 
 # Save the root CA locally for TLS verification
 resource "local_file" "root" {
-  count = "${local.manage_tls}"
+  count = local.manage_tls
 
   filename = "ca.crt"
-  content  = "${tls_self_signed_cert.root.cert_pem}"
+  content  = tls_self_signed_cert.root[0].cert_pem
 }
 
 # Vault server key
 resource "tls_private_key" "vault-server" {
-  count = "${local.manage_tls}"
+  count = local.manage_tls
 
   algorithm = "RSA"
   rsa_bits  = "2048"
@@ -61,33 +74,31 @@ resource "tls_private_key" "vault-server" {
 
 # Create the request to sign the cert with our CA
 resource "tls_cert_request" "vault-server" {
-  count = "${local.manage_tls}"
+  count = local.manage_tls
 
-  key_algorithm   = "${tls_private_key.vault-server.algorithm}"
-  private_key_pem = "${tls_private_key.vault-server.private_key_pem}"
+  key_algorithm   = tls_private_key.vault-server[0].algorithm
+  private_key_pem = tls_private_key.vault-server[0].private_key_pem
 
-  dns_names = ["${var.tls_dns_names}"]
+  dns_names = var.tls_dns_names
 
-  ip_addresses = [
-    "${google_compute_address.vault.address}",
-    "${var.tls_ips}",
-  ]
+  ip_addresses = flatten([
+    google_compute_address.vault.address, var.tls_ips])
 
   subject {
-    common_name         = "${var.tls_cn}"
-    organization        = "${lookup(var.tls_ca_subject, "organization")}"
-    organizational_unit = "${var.tls_ou}"
+    common_name         = var.tls_cn
+    organization        = var.tls_ca_subject["organization"]
+    organizational_unit = var.tls_ou
   }
 }
 
 # Sign the cert
 resource "tls_locally_signed_cert" "vault-server" {
-  count = "${local.manage_tls}"
+  count = local.manage_tls
 
-  cert_request_pem   = "${tls_cert_request.vault-server.cert_request_pem}"
-  ca_key_algorithm   = "${tls_private_key.root.algorithm}"
-  ca_private_key_pem = "${tls_private_key.root.private_key_pem}"
-  ca_cert_pem        = "${tls_self_signed_cert.root.cert_pem}"
+  cert_request_pem   = tls_cert_request.vault-server[0].cert_request_pem
+  ca_key_algorithm   = tls_private_key.root[0].algorithm
+  ca_private_key_pem = tls_private_key.root[0].private_key_pem
+  ca_cert_pem        = tls_self_signed_cert.root[0].cert_pem
 
   validity_period_hours = 17520
   early_renewal_hours   = 8760
@@ -97,48 +108,49 @@ resource "tls_locally_signed_cert" "vault-server" {
 
 # Encrypt server key with GCP KMS
 data "external" "vault-tls-key-encrypted" {
-  count = "${local.manage_tls}"
+  count = local.manage_tls
 
   program = ["${path.module}/scripts/gcpkms-encrypt.sh"]
 
   query = {
-    root     = "${path.module}"
-    data     = "${tls_private_key.vault-server.private_key_pem}"
-    project  = "${var.project_id}"
-    location = "${google_kms_key_ring.vault.location}"
-    keyring  = "${google_kms_key_ring.vault.name}"
-    key      = "${google_kms_crypto_key.vault-init.name}"
+    root     = path.module
+    data     = tls_private_key.vault-server[0].private_key_pem
+    project  = var.project_id
+    location = google_kms_key_ring.vault.location
+    keyring  = google_kms_key_ring.vault.name
+    key      = google_kms_crypto_key.vault-init.name
   }
 
-  depends_on = ["google_kms_crypto_key.vault-init"]
+  depends_on = [google_kms_crypto_key.vault-init]
 }
 
 resource "google_storage_bucket_object" "vault-private-key" {
-  count = "${local.manage_tls}"
+  count = local.manage_tls
 
-  name    = "${var.vault_tls_key_filename}"
-  content = "${data.external.vault-tls-key-encrypted.result["ciphertext"]}"
-  bucket  = "${local.vault_tls_bucket}"
+  name    = var.vault_tls_key_filename
+  content = data.external.vault-tls-key-encrypted.0.result["ciphertext"]
+  bucket  = local.vault_tls_bucket
 
-  depends_on = ["google_storage_bucket.vault"]
+  depends_on = [google_storage_bucket.vault]
 }
 
 resource "google_storage_bucket_object" "vault-server-cert" {
-  count = "${local.manage_tls}"
+  count = local.manage_tls
 
-  name    = "${var.vault_tls_cert_filename}"
-  content = "${tls_locally_signed_cert.vault-server.cert_pem}"
-  bucket  = "${local.vault_tls_bucket}"
+  name    = var.vault_tls_cert_filename
+  content = tls_locally_signed_cert.vault-server[0].cert_pem
+  bucket  = local.vault_tls_bucket
 
-  depends_on = ["google_storage_bucket.vault"]
+  depends_on = [google_storage_bucket.vault]
 }
 
 resource "google_storage_bucket_object" "vault-ca-cert" {
-  count = "${local.manage_tls}"
+  count = local.manage_tls
 
-  name    = "${var.vault_ca_cert_filename}"
-  content = "${tls_self_signed_cert.root.cert_pem}"
-  bucket  = "${local.vault_tls_bucket}"
+  name    = var.vault_ca_cert_filename
+  content = tls_self_signed_cert.root[0].cert_pem
+  bucket  = local.vault_tls_bucket
 
-  depends_on = ["google_storage_bucket.vault"]
+  depends_on = [google_storage_bucket.vault]
 }
+

--- a/variables.tf
+++ b/variables.tf
@@ -18,16 +18,17 @@
 #
 # Project
 # --------------------
-variable project_id {
-  type = "string"
+variable "project_id" {
+  type = string
 
   description = <<EOF
 ID of the project in which to create resources and add IAM bindings.
 EOF
+
 }
 
-variable project_services {
-  type = "list"
+variable "project_services" {
+  type = list(string)
 
   default = [
     "cloudkms.googleapis.com",
@@ -46,15 +47,17 @@ To disable, set to the empty list []. You may want to disable this if the
 services have already been enabled and the current user does not have permission
 to enable new services.
 EOF
+
 }
 
-variable region {
-  type    = "string"
-  default = "us-east4"
+variable "region" {
+type    = string
+default = "us-east4"
 
-  description = <<EOF
+description = <<EOF
 Region in which to create resources.
 EOF
+
 }
 
 #
@@ -62,19 +65,20 @@ EOF
 # GCS
 # --------------------
 
-variable storage_bucket_name {
-  type    = "string"
-  default = ""
+variable "storage_bucket_name" {
+type = string
+default = ""
 
-  description = <<EOF
+description = <<EOF
 Name of the Google Cloud Storage bucket for the Vault backend storage. This must
 be globally unique across of of GCP. If left as the empty string, this will
 default to: "<project-id>-vault-data".
 EOF
+
 }
 
-variable storage_bucket_location {
-  type    = "string"
+variable "storage_bucket_location" {
+  type    = string
   default = "us"
 
   description = <<EOF
@@ -85,15 +89,17 @@ will be stored. Valid values include:
   - eu
   - us
 EOF
+
 }
 
-variable storage_bucket_force_destroy {
-  type    = "string"
+variable "storage_bucket_force_destroy" {
+  type = string
   default = false
 
   description = <<EOF
 Set to true to force deletion of backend bucket on `terraform destroy`.
 EOF
+
 }
 
 #
@@ -101,42 +107,45 @@ EOF
 # IAM
 # --------------------
 
-variable service_account_name {
-  type    = "string"
-  default = "vault-admin"
+variable "service_account_name" {
+type    = string
+default = "vault-admin"
 
-  description = <<EOF
+description = <<EOF
 Name of the Vault service account.
 EOF
+
 }
 
-variable service_account_project_iam_roles {
-  type = "list"
+variable "service_account_project_iam_roles" {
+type = list(string)
 
-  default = [
-    "roles/logging.logWriter",
-    "roles/monitoring.metricWriter",
-    "roles/monitoring.viewer",
-  ]
+default = [
+"roles/logging.logWriter",
+"roles/monitoring.metricWriter",
+"roles/monitoring.viewer",
+]
 
-  description = <<EOF
+description = <<EOF
 List of IAM roles for the Vault admin service account to function. If you need
 to add additional roles, update `service_account_project_additional_iam_roles`
 instead.
 EOF
+
 }
 
-variable service_account_project_additional_iam_roles {
-  type    = "list"
+variable "service_account_project_additional_iam_roles" {
+  type    = list(string)
   default = []
 
   description = <<EOF
 List of custom IAM roles to add to the project.
 EOF
+
 }
 
-variable service_account_storage_bucket_iam_roles {
-  type = "list"
+variable "service_account_storage_bucket_iam_roles" {
+  type = list(string)
 
   default = [
     "roles/storage.legacyBucketReader",
@@ -147,6 +156,7 @@ variable service_account_storage_bucket_iam_roles {
 List of IAM roles for the Vault admin service account to have on the storage
 bucket.
 EOF
+
 }
 
 #
@@ -154,31 +164,34 @@ EOF
 # KMS
 # --------------------
 
-variable kms_keyring {
-  type = "string"
+variable "kms_keyring" {
+type = string
 
-  description = <<EOF
+description = <<EOF
 Name of the Cloud KMS KeyRing for asset encryption.
 EOF
+
 }
 
-variable kms_crypto_key {
-  type    = "string"
-  default = "vault-init"
+variable "kms_crypto_key" {
+type = string
+default = "vault-init"
 
-  description = <<EOF
+description = <<EOF
 The name of the Cloud KMS Key used for encrypting initial TLS certificates and
 for configuring Vault auto-unseal.
 EOF
+
 }
 
-variable kms_protection_level {
-  type    = "string"
+variable "kms_protection_level" {
+  type    = string
   default = "software"
 
   description = <<EOF
 The protection level to use for the KMS crypto key.
 EOF
+
 }
 
 #
@@ -186,13 +199,14 @@ EOF
 # Networking
 # --------------------
 
-variable network_subnet_cidr_range {
-  type    = "string"
+variable "network_subnet_cidr_range" {
+  type = string
   default = "10.127.0.0/20"
 
   description = <<EOF
 CIDR block range for the subnet.
 EOF
+
 }
 
 #
@@ -200,14 +214,15 @@ EOF
 # SSH
 # --------------------
 
-variable ssh_allowed_cidrs {
-  type    = "list"
-  default = ["0.0.0.0/0"]
+variable "ssh_allowed_cidrs" {
+type    = list(string)
+default = ["0.0.0.0/0"]
 
-  description = <<EOF
+description = <<EOF
 List of CIDR blocks to allow access to SSH into nodes. To disable, set to the
 empty list [].
 EOF
+
 }
 
 #
@@ -215,11 +230,11 @@ EOF
 # TLS
 # --------------------
 
-variable manage_tls {
-  type    = "string"
-  default = "true"
+variable "manage_tls" {
+type = string
+default = "true"
 
-  description = <<EOF
+description = <<EOF
 Set to "false" if you'd like to manage and upload your own TLS files, if you do not want this module
 to generate them. By default this module expects the following files at the root of the bucket, but these
 can be overriden:
@@ -227,11 +242,21 @@ can be overriden:
 - `vault.crt`: Vault server public certificate, signed by the ca.crt
 - `vault.key.enc` Vault server certificate private key, encrypted with the kms key provided and base64 encoded.
 EOF
+
 }
 
-variable tls_ca_subject {
+variable "tls_ca_subject" {
   description = "The `subject` block for the root CA certificate."
-  type        = "map"
+  type = object({
+    common_name         = string,
+    organization        = string,
+    organizational_unit = string,
+    street_address      = list(string),
+    locality            = string,
+    province            = string,
+    country             = string,
+    postal_code         = string
+  })
 
   default = {
     common_name         = "Example Inc. Root"
@@ -245,62 +270,66 @@ variable tls_ca_subject {
   }
 }
 
-variable tls_cn {
+variable "tls_cn" {
   description = "The TLS Common Name for the TLS certificates"
   default     = "vault.example.net"
 }
 
-variable tls_dns_names {
+variable "tls_dns_names" {
   description = "List of DNS names added to the Vault server self-signed certificate"
-  type        = "list"
+  type        = list(string)
   default     = ["vault.example.net"]
 }
 
-variable tls_ips {
+variable "tls_ips" {
   description = "List of IP addresses added to the Vault server self-signed certificate"
-  type        = "list"
+  type        = list(string)
   default     = ["127.0.0.1"]
 }
 
-variable tls_ou {
+variable "tls_ou" {
   description = "The TLS Organizational Unit for the TLS certificate"
   default     = "IT Security Operations"
 }
 
-variable vault_ca_cert_filename {
-  type    = "string"
+variable "vault_ca_cert_filename" {
+  type    = string
   default = "ca.crt"
 
   description = <<EOF
 GCS object path within the vault_tls_bucket. This is the root CA certificate.
 EOF
+
 }
 
-variable vault_tls_bucket {
-  type    = "string"
+variable "vault_tls_bucket" {
+  type = string
   default = ""
 
   description = <<EOF
 GCS Bucket override where Vault will expect TLS certificates are stored.
 EOF
+
 }
 
-variable vault_tls_cert_filename {
-  type    = "string"
-  default = "vault.crt"
+variable "vault_tls_cert_filename" {
+type    = string
+default = "vault.crt"
 
-  description = <<EOF
+description = <<EOF
 GCS object path within the vault_tls_bucket. This is the vault server certificate.
 EOF
+
 }
 
-variable vault_tls_key_filename {
-  type    = "string"
-  default = "vault.key.enc"
+variable "vault_tls_key_filename" {
+type = string
+default = "vault.key.enc"
 
-  description = <<EOF
+description = <<EOF
 Encrypted and base64 encoded GCS object path within the vault_tls_bucket. This is the Vault TLS private key.
 EOF
+
 }
 
 #
@@ -308,8 +337,8 @@ EOF
 # Vault
 # --------------------
 
-variable vault_allowed_cidrs {
-  type    = "list"
+variable "vault_allowed_cidrs" {
+  type    = list(string)
   default = ["0.0.0.0/0"]
 
   description = <<EOF
@@ -321,85 +350,96 @@ Vault). It is recommended that you reduce this to a smaller list.
 To disable, set to the empty list []. Even if disabled, internal rules will
 still allow the health checker to probe the nodes for health.
 EOF
+
 }
 
-variable vault_args {
-  type    = "string"
+variable "vault_args" {
+  type = string
   default = ""
 
   description = <<EOF
 Additional command line arguments passed to Vault server/
 EOF
+
 }
 
-variable vault_instance_labels {
-  type    = "map"
-  default = {}
+variable "vault_instance_labels" {
+type    = map(string)
+default = {}
 
-  description = <<EOF
+description = <<EOF
 Labels to apply to the Vault instances.
 EOF
+
 }
 
-variable vault_instance_metadata {
-  type    = "map"
-  default = {}
+variable "vault_instance_metadata" {
+type = map(string)
+default = {}
 
-  description = <<EOF
+description = <<EOF
 Additional metadata to add to the Vault instances.
 EOF
+
 }
 
-variable vault_instance_tags {
-  type    = "list"
-  default = []
+variable "vault_instance_tags" {
+  type    = list(string)
+  default = [    
+      "allow-ssh",
+    "allow-vault"]
 
   description = <<EOF
 Additional tags to apply to the instances. Note "allow-ssh" and "allow-vault"
 will be present on all instances.
 EOF
+
 }
 
-variable vault_log_level {
-  type    = "string"
+variable "vault_log_level" {
+  type = string
   default = "warn"
 
   description = <<EOF
 Log level to run Vault in. See the Vault documentation for valid values.
 EOF
+
 }
 
-variable vault_min_num_servers {
-  type    = "string"
-  default = "1"
+variable "vault_min_num_servers" {
+type    = string
+default = "1"
 
-  description = <<EOF
+description = <<EOF
 Minimum number of Vault server nodes in the autoscaling group. The group will
 not have less than this number of nodes.
 EOF
+
 }
 
-variable vault_machine_type {
-  type    = "string"
-  default = "n1-standard-1"
+variable "vault_machine_type" {
+type = string
+default = "n1-standard-1"
 
-  description = <<EOF
+description = <<EOF
 Machine type to use for Vault instances.
 EOF
+
 }
 
-variable vault_max_num_servers {
-  type    = "string"
+variable "vault_max_num_servers" {
+  type    = string
   default = "7"
 
   description = <<EOF
 Maximum number of Vault server nodes to run at one time. The group will not
 autoscale beyond this number.
 EOF
+
 }
 
-variable vault_port {
-  type    = "string"
+variable "vault_port" {
+  type = string
   default = "8200"
 
   description = <<EOF
@@ -407,45 +447,51 @@ Numeric port on which to run and expose Vault. This should be a high-numbered
 port, since Vault does not run as a root user and therefore cannot bind to
 privledged ports like 80 or 443. The default is 8200, the standard Vault port.
 EOF
+
 }
 
-variable vault_proxy_port {
-  type    = "string"
-  default = "58200"
+variable "vault_proxy_port" {
+type    = string
+default = "58200"
 
-  description = <<EOF
+description = <<EOF
 Port to expose Vault's health status endpoint on over HTTP on /. This is
 required for the health checks to verify Vault's status. Only the health status
 endpoint is exposed, and it is only accessible from Google's load balancer
 addresses.
 EOF
+
 }
 
-variable vault_tls_disable_client_certs {
-  type    = "string"
-  default = false
+variable "vault_tls_disable_client_certs" {
+type = string
+default = false
 
-  description = <<EOF
+description = <<EOF
 Use and expect client certificates. You may want to disable this if users will
 not be authenticating to Vault with client certificates.
 EOF
+
 }
 
-variable vault_ui_enabled {
-  type    = "string"
+variable "vault_ui_enabled" {
+  type    = string
   default = true
 
   description = <<EOF
 Controls whether the Vault UI is enabled and accessible.
 EOF
+
 }
 
-variable vault_version {
-  type    = "string"
+variable "vault_version" {
+  type = string
   default = "1.0.3"
 
   description = <<EOF
 Version of vault to install. This version must be 1.0+ and must be published on
 the HashiCorp releases service.
 EOF
+
 }
+


### PR DESCRIPTION
All the elements in a map  must have the same type as per Hashicorp Configuration Language.
Faced an error as value not compatible with the variable's type constraint (i.e. for a map which includes elements having different data types).
Used an object type, which allows you to specify the type for each attribute individually, rather than map where all of the elements must have same type.
Faced issues while using a list of strings for variables like ip_address, street_address.
In previous version for Terraform the surrounding brackets were required even though the expression inside returns a list but v0.12 removed it.
Used 'flatten' method to resolve the issue.