### PR TITLE
Add project as a resource argument for vault-admin

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -48,6 +48,7 @@ resource "google_project_service" "service" {
 resource "google_service_account" "vault-admin" {
   account_id   = "${var.service_account_name}"
   display_name = "Vault Admin"
+  project = "${var.project_id}"
 
   depends_on = ["google_project_service.service"]
 }


### PR DESCRIPTION
Previously the google_service_account for vault-admin
resource didn't define the project_id that the resource
would be associated with.  This means that it is implied by
the initial terraform apply.

Due to a bug in terraform-provider-google
(terraform-providers/terraform-provider-google#4170),
changes to the project_id are not noticed by terraform.
Therefore if the project_id from the module definition is
changed after initial deployment, the resource of the
google_service_account is not changed/recreated.

This is resolved by adding project as a resource argument
for vault-admin google_service_account.

This closes
terraform-google-modules/terraform-google-vault#55, but can
probably be backed out when the provider bug is resolved.

Signed-off-by: Dave Walker (Daviey) <email@daviey.com>