### PR TITLE
allow to create a preemptible instances

### DIFF
--- a/servers.tf
+++ b/servers.tf
@@ -60,6 +60,11 @@ resource "google_compute_instance_template" "vault" {
     create_before_destroy = true
   }
 
+  scheduling {
+    automatic_restart = var.vault_automatic_restart_instance
+    preemptible       = var.vault_preemptible_instances
+  }
+
   depends_on = [google_project_service.service]
 }
 

--- a/variables.tf
+++ b/variables.tf
@@ -474,6 +474,28 @@ EOF
 
 }
 
+variable "vault_preemptible_instances" {
+  type    = bool
+  default = false
+
+  description = <<EOF
+Preemptible instances are recommended only for fault-tolerant applications
+that can withstand instance preemptions.
+EOF
+
+}
+
+variable "vault_automatic_restart_instance" {
+  type    = bool
+  default = true
+
+  description = <<EOF
+Specifies whether the instance should be automatically restarted if it is
+terminated by Compute Engine.
+EOF
+
+}
+
 variable "vault_max_num_servers" {
   type    = string
   default = "7"


### PR DESCRIPTION
hey!

I thought that it would be nice to have these options, as someone would need a proof of concept and [preemptible instances](https://cloud.google.com/compute/docs/instances/preemptible) can cut some costs at the beginning.

