### PR TITLE
Fixes  vault address output in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,7 +81,7 @@ the tag that corresponds to your version for the correct documentation.
 1. Configure your local Vault binary to communicate with the Vault server:
 
     ```
-    $ export VAULT_ADDR="$(terraform output vault_addr)"
+    $ export VAULT_ADDR="$(terraform output vault-address)"
     $ export VAULT_CACERT="$(pwd)/ca.crt"
     ```
 


### PR DESCRIPTION
The ready-to-paste scripts in the README referred to an output which does not exist anymore: `vault_addr`. The correct name is `vault-address`.