### PR TITLE
Older versions of the TLS plugin not compatible with TF12

### DIFF
--- a/tls.tf
+++ b/tls.tf
@@ -19,6 +19,10 @@
 # Vault.
 #
 
+provider "tls" {
+  version = "~> 2.1.1"
+}
+
 locals {
   manage_tls_count          = var.manage_tls ? 1 : 0
   tls_save_ca_to_disk_count = var.tls_save_ca_to_disk ? 1 : 0

--- a/variables.tf
+++ b/variables.tf
@@ -103,7 +103,8 @@ variable "storage_bucket_enable_versioning" {
   default = false
 
   description = <<EOF
-Set to true to enable object versioning in the GCS bucket.
+Set to true to enable object versioning in the GCS bucket.. You may want to
+define lifecycle rules if you want a finite number of old versions.
 EOF
 
 }


### PR DESCRIPTION
So setting the min version that is compatible with tf12. Without this, projects that were initialized with an old version of this module (tf11) will see their plugin not be upgraded and erroring when trying to migrate to the tf12 module version