### PR TITLE
Extra module output - resulting data/backend bucket

### DIFF
--- a/outputs.tf
+++ b/outputs.tf
@@ -76,3 +76,11 @@ EOF
 
 }
 
+output "vault_storage_bucket" {
+  value = google_storage_bucket.vault.name
+
+  description = <<EOF
+GCS Bucket Vault is using as a backend/database
+EOF
+
+}


### PR DESCRIPTION
I'd suggest to output the bucket that has been created to store vault data, so the caller can easily refer to it / concatenate operations if needed (for instance: creating a service account that can read, in order to perform backups)