### PR TITLE
Add an option to require client certs

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -137,15 +137,16 @@ data "template_file" "vault-config" {
   template = file(format("%s/scripts/config.hcl.tpl", path.module))
 
   vars = {
-    kms_project                    = var.project_id
-    kms_location                   = google_kms_key_ring.vault.location
-    kms_keyring                    = google_kms_key_ring.vault.name
-    kms_crypto_key                 = google_kms_crypto_key.vault-init.name
-    lb_ip                          = google_compute_address.vault.address
-    storage_bucket                 = google_storage_bucket.vault.name
-    vault_log_level                = var.vault_log_level
-    vault_port                     = var.vault_port
-    vault_tls_disable_client_certs = var.vault_tls_disable_client_certs
-    vault_ui_enabled               = var.vault_ui_enabled
+    kms_project                              = var.project_id
+    kms_location                             = google_kms_key_ring.vault.location
+    kms_keyring                              = google_kms_key_ring.vault.name
+    kms_crypto_key                           = google_kms_crypto_key.vault-init.name
+    lb_ip                                    = google_compute_address.vault.address
+    storage_bucket                           = google_storage_bucket.vault.name
+    vault_log_level                          = var.vault_log_level
+    vault_port                               = var.vault_port
+    vault_tls_disable_client_certs           = var.vault_tls_disable_client_certs
+    vault_tls_require_and_verify_client_cert = var.vault_tls_require_and_verify_client_cert
+    vault_ui_enabled                         = var.vault_ui_enabled
   }
 }

--- a/scripts/config.hcl.tpl
+++ b/scripts/config.hcl.tpl
@@ -36,7 +36,8 @@ listener "tcp" {
   tls_key_file       = "/etc/vault.d/tls/vault.key"
   tls_client_ca_file = "/etc/vault.d/tls/ca.crt"
 
-  tls_disable_client_certs = "${vault_tls_disable_client_certs}"
+  tls_disable_client_certs           = "${vault_tls_disable_client_certs}"
+  tls_require_and_verify_client_cert = "${vault_tls_require_and_verify_client_cert}"
 }
 
 # Create an mTLS listener locally. Client's shouldn't talk to Vault directly,
@@ -48,7 +49,8 @@ listener "tcp" {
   tls_key_file       = "/etc/vault.d/tls/vault.key"
   tls_client_ca_file = "/etc/vault.d/tls/ca.crt"
 
-  tls_disable_client_certs = "${vault_tls_disable_client_certs}"
+  tls_disable_client_certs           = "${vault_tls_disable_client_certs}"
+  tls_require_and_verify_client_cert = "${vault_tls_require_and_verify_client_cert}"
 }
 
 # Send data to statsd (Stackdriver monitoring)

--- a/variables.tf
+++ b/variables.tf
@@ -508,7 +508,18 @@ variable "vault_tls_disable_client_certs" {
   default = false
 
   description = <<EOF
-Use and expect client certificates. You may want to disable this if users will
+Use client certificates when provided. You may want to disable this if users will
+not be authenticating to Vault with client certificates.
+EOF
+
+}
+
+variable "vault_tls_require_and_verify_client_cert" {
+  type    = string
+  default = false
+
+  description = <<EOF
+Always use client certificates. You may want to disable this if users will
 not be authenticating to Vault with client certificates.
 EOF
 


### PR DESCRIPTION
Hello!

This PR adds the `vault_tls_require_and_verify_client_cert` Vault configuration option to the inputs of the module.

Before, it was possible to choose whether Vault would reject or allow client certificates, but there was no way to require them.
This option adds the possibility to enforce mutual TLS to talk to Vault, and it is disabled by default.

This was tested with `vault_version = "1.3.0"`.