### PR TITLE
Allow internal LB and choice for egress

### DIFF
--- a/examples/vault-on-gce/main.tf
+++ b/examples/vault-on-gce/main.tf
@@ -1,5 +1,5 @@
 #
-# Copyright 2018 Google Inc.
+# Copyright 2020 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -14,35 +14,6 @@
 # limitations under the License.
 #
 
-variable "project_id" {
-  type        = string
-  description = "Project ID in which to deploy"
-}
-
-variable "region" {
-  type        = string
-  default     = "us-east4"
-  description = "Region in which to deploy"
-}
-
-variable "kms_location" {
-  type        = string
-  default     = "us-east4"
-  description = "Location for the KMS keyring"
-}
-
-variable "kms_keyring" {
-  type        = string
-  default     = "vault"
-  description = "Name of the GCP KMS keyring"
-}
-
-variable "kms_crypto_key" {
-  type        = string
-  default     = "vault-init"
-  description = "Name of the GCP KMS crypto key"
-}
-
 module "vault" {
   // source = "terraform-google-modules/vault/google"
 
@@ -54,6 +25,8 @@ module "vault" {
   kms_crypto_key = var.kms_crypto_key
 
   storage_bucket_force_destroy = true
+  load_balancing_scheme        = var.load_balancing_scheme
+  allow_public_egress          = var.allow_public_egress
 }
 
 output "vault_addr" {

--- a/examples/vault-on-gce/variables.tf
+++ b/examples/vault-on-gce/variables.tf
@@ -1,0 +1,61 @@
+#
+# Copyright 2020 Google Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+variable "project_id" {
+  type        = string
+  description = "Project ID in which to deploy"
+}
+
+variable "region" {
+  type        = string
+  default     = "us-east4"
+  description = "Region in which to deploy"
+}
+
+variable "kms_location" {
+  type        = string
+  default     = "us-east4"
+  description = "Location for the KMS keyring"
+}
+
+variable "kms_keyring" {
+  type        = string
+  default     = "vault"
+  description = "Name of the GCP KMS keyring"
+}
+
+variable "kms_crypto_key" {
+  type        = string
+  default     = "vault-init"
+  description = "Name of the GCP KMS crypto key"
+}
+
+variable "load_balancing_scheme" {
+  type        = string
+  default     = "EXTERNAL"
+  description = "e.g. [INTERNAL|EXTERNAL]. Scheme of the load balancer"
+}
+
+variable "allow_public_egress" {
+  type        = bool
+  default     = true
+  description = <<EOF
+Whether to create a NAT for external egress. If false, you must also specify an http_proxy to download required
+executables including Vault, Fluentd and Stackdriver
+EOF
+}
+
+

--- a/main.tf
+++ b/main.tf
@@ -16,6 +16,7 @@
 
 locals {
   vault_tls_bucket = var.vault_tls_bucket != "" ? var.vault_tls_bucket : local.storage_bucket_name
+  lb_ip            = local.use_external_lb ? google_compute_forwarding_rule.external[0].ip_address : var.internal_lb_ip
 }
 
 # Configure the Google provider, locking to the 2.0 series.
@@ -115,6 +116,7 @@ data "template_file" "vault-startup-script" {
 
   vars = {
     config                  = data.template_file.vault-config.rendered
+    custom_http_proxy       = var.http_proxy
     service_account_email   = google_service_account.vault-admin.email
     vault_args              = var.vault_args
     vault_port              = var.vault_port
@@ -140,7 +142,7 @@ data "template_file" "vault-config" {
     kms_location                             = google_kms_key_ring.vault.location
     kms_keyring                              = google_kms_key_ring.vault.name
     kms_crypto_key                           = google_kms_crypto_key.vault-init.name
-    lb_ip                                    = google_compute_address.vault.address
+    lb_ip                                    = local.lb_ip
     storage_bucket                           = google_storage_bucket.vault.name
     vault_log_level                          = var.vault_log_level
     vault_port                               = var.vault_port

--- a/main.tf
+++ b/main.tf
@@ -16,7 +16,7 @@
 
 locals {
   vault_tls_bucket = var.vault_tls_bucket != "" ? var.vault_tls_bucket : local.storage_bucket_name
-  lb_ip            = local.use_external_lb ? google_compute_forwarding_rule.external[0].ip_address : var.internal_lb_ip
+  lb_ip            = local.use_external_lb ? google_compute_forwarding_rule.external[0].ip_address : google_compute_address.vault_ilb[0].address
 }
 
 # Configure the Google provider, locking to the 2.0 series.
@@ -118,6 +118,7 @@ data "template_file" "vault-startup-script" {
     config                  = data.template_file.vault-config.rendered
     custom_http_proxy       = var.http_proxy
     service_account_email   = google_service_account.vault-admin.email
+    internal_lb             = local.use_internal_lb
     vault_args              = var.vault_args
     vault_port              = var.vault_port
     vault_proxy_port        = var.vault_proxy_port

--- a/network.tf
+++ b/network.tf
@@ -32,6 +32,15 @@ resource "google_compute_address" "vault-nat" {
   depends_on = [google_project_service.service]
 }
 
+resource "google_compute_address" "vault_ilb" {
+  count        = local.use_internal_lb ? 1 : 0
+  subnetwork   = local.subnet
+  name         = "vault-ilb"
+  address_type = "INTERNAL"
+
+  depends_on = [google_project_service.service]
+}
+
 # Create a NAT router so the nodes can reach the public Internet
 resource "google_compute_router" "vault-router" {
   count   = var.allow_public_egress ? 1 : 0

--- a/network.tf
+++ b/network.tf
@@ -125,7 +125,7 @@ resource "google_compute_firewall" "allow-lb-healthcheck" {
 
   allow {
     protocol = "tcp"
-    ports    = [var.vault_proxy_port]
+    ports    = [local.use_internal_lb ? var.vault_port : var.vault_proxy_port]
   }
 
   source_ranges = concat(data.google_compute_lb_ip_ranges.ranges.network, data.google_compute_lb_ip_ranges.ranges.http_ssl_tcp_internal)

--- a/outputs.tf
+++ b/outputs.tf
@@ -44,7 +44,7 @@ EOF
 }
 
 output "vault_addr" {
-  value = "https://${google_compute_address.vault.address}:${var.vault_port}"
+  value = "https://${local.lb_ip}:${var.vault_port}"
 
   description = <<EOF
 Full protocol, address, and port (FQDN) pointing to the Vault load balancer.
@@ -58,7 +58,7 @@ EOF
 }
 
 output "vault_lb_addr" {
-  value = google_compute_address.vault.address
+  value = local.lb_ip
 
   description = <<EOF
 Address of the load balancer without port or protocol information. You probably
@@ -86,16 +86,16 @@ EOF
 }
 
 output "vault_network" {
-  value = local.network
+  value       = local.network
   description = "The network in which the Vault cluster resides"
 }
 
 output "vault_subnet" {
-  value = local.subnet
+  value       = local.subnet
   description = "The subnetwork in which the Vault cluster resides"
 }
 
 output "vault_nat_ips" {
-  value = google_compute_address.vault-nat.*.address
+  value       = google_compute_address.vault-nat.*.address
   description = "The NAT-ips that the vault nodes will use to communicate with external services."
 }

--- a/scripts/startup.sh.tpl
+++ b/scripts/startup.sh.tpl
@@ -11,11 +11,17 @@ fi
 # Data
 LOCAL_IP="$(curl -sf -H "Metadata-Flavor: Google" http://metadata/computeMetadata/v1/instance/network-interfaces/0/ip)"
 
+# Allow users to specify an HTTP proxy for egress instead of a NAT
+if [ ! -z '${custom_http_proxy}' ]; then
+  export http_proxy=${custom_http_proxy}
+  export https_proxy=$http_proxy
+fi
+
 # Deps
 export DEBIAN_FRONTEND=noninteractive
 apt-get update -yqq
 apt-get upgrade -yqq
-apt-get install -yqq jq libcap2-bin logrotate netcat nginx unzip
+apt-get install -yqq jq libcap2-bin logrotate nginx unzip
 
 # Install Stackdriver for logging and monitoring
 curl -sSfL https://dl.google.com/cloudagents/install-logging-agent.sh | bash

--- a/servers.tf
+++ b/servers.tf
@@ -20,9 +20,9 @@
 
 # Template for creating Vault nodes
 locals {
-  use_internal_lb = var.load_balancing_scheme == "INTERNAL"
-  use_external_lb = var.load_balancing_scheme == "EXTERNAL"
-
+  lb_scheme = upper(var.load_balancing_scheme)
+  use_internal_lb = local.lb_scheme == "INTERNAL"
+  use_external_lb = local.lb_scheme == "EXTERNAL"
 }
 
 resource "google_compute_instance_template" "vault" {
@@ -110,7 +110,7 @@ resource "google_compute_forwarding_rule" "vault_internal" {
   region                = var.region
   ip_protocol           = "TCP"
   ip_address            = google_compute_address.vault_ilb[0].address
-  load_balancing_scheme = var.load_balancing_scheme
+  load_balancing_scheme = local.lb_scheme
   network_tier          = "PREMIUM"
   allow_global_access   = true
   subnetwork            = local.subnet
@@ -163,7 +163,7 @@ resource "google_compute_forwarding_rule" "external" {
   region                = var.region
   ip_address            = google_compute_address.vault[0].address
   ip_protocol           = "TCP"
-  load_balancing_scheme = var.load_balancing_scheme
+  load_balancing_scheme = local.lb_scheme
   network_tier          = "PREMIUM"
 
   target     = google_compute_target_pool.vault[0].self_link

--- a/servers.tf
+++ b/servers.tf
@@ -19,6 +19,12 @@
 #
 
 # Template for creating Vault nodes
+locals {
+  use_internal_lb = var.load_balancing_scheme == "INTERNAL"
+  use_external_lb = var.load_balancing_scheme == "EXTERNAL"
+
+}
+
 resource "google_compute_instance_template" "vault" {
   project     = var.project_id
   region      = var.region
@@ -63,51 +69,110 @@ resource "google_compute_instance_template" "vault" {
   depends_on = [google_project_service.service]
 }
 
-# This legacy health check is required because the target pool requires an HTTP
-# health check.
-resource "google_compute_http_health_check" "vault" {
-  project = var.project_id
+############################
+## Internal Load Balancer ##
+############################
 
-  name         = "vault-health-legacy"
-  request_path = "/"
-  port         = var.vault_proxy_port
+resource "google_compute_health_check" "vault_internal" {
+  count   = local.use_internal_lb ? 1 : 0
+  project = var.project_id
+  name    = "vault-health-internal"
 
   check_interval_sec  = 15
   timeout_sec         = 5
   healthy_threshold   = 2
   unhealthy_threshold = 2
 
+  http_health_check {
+    port = var.vault_proxy_port
+  }
+
   depends_on = [google_project_service.service]
 }
 
-# Target pool for vault nodes
+resource "google_compute_region_backend_service" "vault_internal" {
+  count         = local.use_internal_lb ? 1 : 0
+  name          = "vault-backend-service"
+  region        = var.region
+  health_checks = ["${google_compute_health_check.vault_internal[0].self_link}"]
+  backend {
+    group = google_compute_region_instance_group_manager.vault.instance_group
+  }
+}
+
+# Forward internal traffic to the backend service
+resource "google_compute_forwarding_rule" "vault_internal" {
+  provider = google-beta
+  count    = local.use_internal_lb ? 1 : 0
+  project  = var.project_id
+
+  name                  = "vault-internal"
+  region                = var.region
+  ip_protocol           = "TCP"
+  ip_address            = var.internal_lb_ip
+  load_balancing_scheme = var.load_balancing_scheme
+  network_tier          = "PREMIUM"
+  allow_global_access   = true # BETA
+  subnetwork            = local.subnet
+
+  backend_service = google_compute_region_backend_service.vault_internal[0].self_link
+  ports           = [var.vault_port]
+
+  depends_on = [google_project_service.service]
+}
+
+############################
+## External Load Balancer ##
+############################
+
+# This legacy health check is required because the target pool requires an HTTP
+# health check.
+resource "google_compute_http_health_check" "vault" {
+  count   = local.use_external_lb ? 1 : 0
+  project = var.project_id
+  name    = "vault-health-legacy"
+
+  check_interval_sec  = 15
+  timeout_sec         = 5
+  healthy_threshold   = 2
+  unhealthy_threshold = 2
+  port                = var.vault_proxy_port
+
+  depends_on = [google_project_service.service]
+}
+
+
 resource "google_compute_target_pool" "vault" {
+  count   = local.use_external_lb ? 1 : 0
   project = var.project_id
 
   name   = "vault-tp"
   region = var.region
 
-  health_checks = [google_compute_http_health_check.vault.name]
+  health_checks = [google_compute_http_health_check.vault[0].name]
 
   depends_on = [google_project_service.service]
 }
 
 # Forward external traffic to the target pool
-resource "google_compute_forwarding_rule" "vault" {
+resource "google_compute_forwarding_rule" "external" {
+  count   = local.use_external_lb ? 1 : 0
   project = var.project_id
 
-  name                  = "vault"
+  name                  = "vault-external"
   region                = var.region
-  ip_address            = google_compute_address.vault.address
+  ip_address            = google_compute_address.vault[0].address
   ip_protocol           = "TCP"
-  load_balancing_scheme = "EXTERNAL"
+  load_balancing_scheme = var.load_balancing_scheme
   network_tier          = "PREMIUM"
 
-  target     = google_compute_target_pool.vault.self_link
+  target     = google_compute_target_pool.vault[0].self_link
   port_range = var.vault_port
 
   depends_on = [google_project_service.service]
 }
+
+
 
 # Vault instance group manager
 resource "google_compute_region_instance_group_manager" "vault" {
@@ -119,7 +184,7 @@ resource "google_compute_region_instance_group_manager" "vault" {
   base_instance_name = "vault-${var.region}"
   wait_for_instances = false
 
-  target_pools = [google_compute_target_pool.vault.self_link]
+  target_pools = local.use_external_lb ? [google_compute_target_pool.vault[0].self_link] : []
 
   named_port {
     name = "vault-http"

--- a/servers.tf
+++ b/servers.tf
@@ -20,7 +20,7 @@
 
 # Template for creating Vault nodes
 locals {
-  lb_scheme = upper(var.load_balancing_scheme)
+  lb_scheme       = upper(var.load_balancing_scheme)
   use_internal_lb = local.lb_scheme == "INTERNAL"
   use_external_lb = local.lb_scheme == "EXTERNAL"
 }
@@ -96,6 +96,7 @@ resource "google_compute_region_backend_service" "vault_internal" {
   name          = "vault-backend-service"
   region        = var.region
   health_checks = ["${google_compute_health_check.vault_internal[0].self_link}"]
+
   backend {
     group = google_compute_region_instance_group_manager.vault.instance_group
   }

--- a/tls.tf
+++ b/tls.tf
@@ -86,7 +86,7 @@ resource "tls_cert_request" "vault-server" {
 
   dns_names = var.tls_dns_names
 
-  ip_addresses = concat([google_compute_address.vault.address], var.tls_ips)
+  ip_addresses = concat([local.lb_ip], var.tls_ips)
 
   subject {
     common_name         = var.tls_cn

--- a/variables.tf
+++ b/variables.tf
@@ -284,15 +284,6 @@ EOF
 
 }
 
-variable "internal_lb_ip" {
-  type    = string
-  default = "10.127.13.37"
-
-  description = <<EOF
-If load_balancing_scheme is set to INTERNAL, this IP will be used as the forwarding rule IP
-EOF
-}
-
 variable "http_proxy" {
   type    = string
   default = ""

--- a/variables.tf
+++ b/variables.tf
@@ -172,9 +172,6 @@ variable "service_account_project_iam_roles" {
     "roles/logging.logWriter",
     "roles/monitoring.metricWriter",
     "roles/monitoring.viewer",
-
-    # Used to get internal load balancer IP in startup script
-    "roles/compute.networkViewer",
   ]
 
   description = <<EOF
@@ -295,6 +292,7 @@ i.e. If you configure Vault to manage credentials for other services, default HT
 EOF
 }
 
+#TODO: Evaluate https://www.terraform.io/docs/configuration/variables.html#custom-validation-rules when prod ready
 variable "load_balancing_scheme" {
   type    = string
   default = "EXTERNAL"

--- a/versions.tf
+++ b/versions.tf
@@ -2,6 +2,7 @@ terraform {
   required_version = ">= 0.12"
 
   required_providers {
-    google = "~> 3.4"
+    google      = "~> 3.4"
+    google-beta = "~> 3.4"
   }
 }

--- a/versions.tf
+++ b/versions.tf
@@ -2,7 +2,6 @@ terraform {
   required_version = ">= 0.12"
 
   required_providers {
-    google      = "~> 3.4"
-    google-beta = "~> 3.4"
+    google = "~> 3.15"
   }
 }


### PR DESCRIPTION
Fixes #57
Fixes #82

_NOTE: This release forces creation of new template and thus Vault nodes will need to be replaced._

* Add new variable for choosing if you want external LB created or not. Default to external to ease migration burden
* Add ability for users to specify an http_proxy such as Squid and choose not to create a NAT.