### PR TITLE
Make ssh access optional

### DIFF
--- a/network.tf
+++ b/network.tf
@@ -159,6 +159,7 @@ resource "google_compute_firewall" "allow-internal" {
 
 # Allow SSHing into machines tagged "allow-ssh"
 resource "google_compute_firewall" "allow-ssh" {
+  count   = var.allow_ssh ? 1 : 0
   project = var.project_id
   name    = "vault-allow-ssh"
   network = local.network

--- a/variables.tf
+++ b/variables.tf
@@ -276,13 +276,21 @@ EOF
 # SSH
 # --------------------
 
+variable "allow_ssh" {
+  type        = bool
+  default     = true
+  description = <<EOF
+Allow external access to ssh port 22 on the Vault VMs. It is a best practice to set this to false,
+however it is true by default for the sake of backwards compatibility.
+EOF
+}
+
 variable "ssh_allowed_cidrs" {
   type    = list(string)
   default = ["0.0.0.0/0"]
 
   description = <<EOF
-List of CIDR blocks to allow access to SSH into nodes. To disable, set to the
-empty list [].
+List of CIDR blocks to allow access to SSH into nodes.
 EOF
 
 }


### PR DESCRIPTION
It is best practice to deny SSH access, something alluded to in #83 . Since users of this module may not be pinning the version, I've set it to default allow SSH to ensure backwards compatibility.