### PR TITLE
Fixed TLS bucket dependency issues

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -15,8 +15,10 @@
 #
 
 locals {
-  vault_tls_bucket = var.vault_tls_bucket != "" ? var.vault_tls_bucket : local.storage_bucket_name
-  lb_ip            = local.use_external_lb ? google_compute_forwarding_rule.external[0].ip_address : google_compute_address.vault_ilb[0].address
+  vault_tls_bucket  = var.vault_tls_bucket != "" ? var.vault_tls_bucket : local.storage_bucket_name
+  default_kms_key   = "projects/${var.project_id}/locations/${var.region}/keyRings/${var.kms_keyring}/cryptoKeys/${var.kms_crypto_key}"
+  vault_tls_kms_key = var.vault_tls_kms_key != "" ? var.vault_tls_kms_key : local.default_kms_key
+  lb_ip             = local.use_external_lb ? google_compute_forwarding_rule.external[0].ip_address : google_compute_address.vault_ilb[0].address
 }
 
 # Configure the Google provider, locking to the 2.0 series.
@@ -85,6 +87,22 @@ resource "google_kms_crypto_key_iam_member" "ck-iam" {
   depends_on = [google_project_service.service]
 }
 
+resource "google_kms_crypto_key_iam_member" "tls-ck-iam" {
+  count = var.manage_tls == false ? 1 : 0
+
+  crypto_key_id = var.vault_tls_kms_key
+  role          = "roles/cloudkms.cryptoKeyDecrypter"
+  member        = "serviceAccount:${google_service_account.vault-admin.email}"
+}
+
+resource "google_storage_bucket_iam_member" "tls-bucket-iam" {
+  count = var.manage_tls == false ? 1 : 0
+
+  bucket = var.vault_tls_bucket
+  role   = "roles/storage.objectViewer"
+  member = "serviceAccount:${google_service_account.vault-admin.email}"
+}
+
 # Create the KMS key ring
 resource "google_kms_key_ring" "vault" {
   name     = var.kms_keyring
@@ -124,10 +142,8 @@ data "template_file" "vault-startup-script" {
     vault_ca_cert_filename  = var.vault_ca_cert_filename
     vault_tls_key_filename  = var.vault_tls_key_filename
     vault_tls_cert_filename = var.vault_tls_cert_filename
-    kms_project             = var.project_id
-    kms_location            = google_kms_key_ring.vault.location
-    kms_keyring             = google_kms_key_ring.vault.name
-    kms_crypto_key          = google_kms_crypto_key.vault-init.name
+    kms_project             = var.vault_tls_kms_key_project == "" ? var.project_id : var.vault_tls_kms_key_project
+    kms_crypto_key          = local.vault_tls_kms_key
     user_startup_script     = var.user_startup_script
   }
 }

--- a/scripts/startup.sh.tpl
+++ b/scripts/startup.sh.tpl
@@ -66,8 +66,6 @@ gsutil cp "gs://${vault_tls_bucket}/${vault_tls_key_filename}" /etc/vault.d/tls/
 # Decrypt the Vault private key
 base64 --decode < /etc/vault.d/tls/vault.key.enc | gcloud kms decrypt \
   --project="${kms_project}" \
-  --location="${kms_location}" \
-  --keyring="${kms_keyring}" \
   --key="${kms_crypto_key}" \
   --plaintext-file=/etc/vault.d/tls/vault.key \
   --ciphertext-file=-

--- a/variables.tf
+++ b/variables.tf
@@ -588,6 +588,29 @@ EOF
 
 }
 
+variable "vault_tls_kms_key" {
+  type    = string
+  default = ""
+
+  description = <<EOF
+Fully qualified name of the KMS key, for example,
+vault_tls_kms_key = "projects/PROJECT_ID/locations/LOCATION/keyRings/KEYRING/cryptoKeys/KEY_NAME"
+This key should have been used to encrypt the TLS private key if Terraform is
+not managing TLS. The Vault service account will be granted access to the KMS Decrypter
+role once it is created so it can pull from this the `vault_tls_bucket` at boot time. This
+option is required when `manage_tls` is set to false.
+EOF
+}
+
+variable "vault_tls_kms_key_project" {
+  type    = string
+  default = ""
+
+  description = <<EOF
+Project ID where the KMS key is stored. By default, same as `project_id`
+EOF
+}
+
 variable "vault_tls_cert_filename" {
   type    = string
   default = "vault.crt"


### PR DESCRIPTION
Before this fix it was impossible to pass in TLS certificates in a bucket and have Vault read them without restarting Vault somewhere along the line, since the KMS key expected to encrypt them was being created by this module. This makes the process easier by allowing a separate KMS key for TLS keys where the `vault-admin` service account is granted access to view and decrypt after it's created.