### PR TITLE
Added user startup script

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -128,6 +128,7 @@ data "template_file" "vault-startup-script" {
     kms_location            = google_kms_key_ring.vault.location
     kms_keyring             = google_kms_key_ring.vault.name
     kms_crypto_key          = google_kms_crypto_key.vault-init.name
+    user_startup_script     = var.user_startup_script
   }
 }
 

--- a/scripts/startup.sh.tpl
+++ b/scripts/startup.sh.tpl
@@ -268,6 +268,12 @@ curl -sSfLo /opt/stackdriver/collectd/etc/collectd.d/statsd.conf https://raw.git
 systemctl enable stackdriver-agent
 systemctl restart stackdriver-agent
 
+#########################################
+##          user_startup_script        ##
+#########################################
+${user_startup_script}
+
+
 # Signal this script has run
 touch ~/.startup-script-complete
 

--- a/variables.tf
+++ b/variables.tf
@@ -628,3 +628,12 @@ the HashiCorp releases service.
 EOF
 
 }
+
+variable "user_startup_script" {
+  type = string
+  default = ""
+
+  description = <<EOF
+Additional user-provided code injected after Vault is setup
+EOF
+}


### PR DESCRIPTION
Allow users to pass in their own configuration code after Vault has finished installing. This is useful for things like installing custom Vault plugins, etc.