### PR TITLE
Made some TLS fixes to allow plugins to work

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -19,6 +19,7 @@ locals {
   default_kms_key   = "projects/${var.project_id}/locations/${var.region}/keyRings/${var.kms_keyring}/cryptoKeys/${var.kms_crypto_key}"
   vault_tls_kms_key = var.vault_tls_kms_key != "" ? var.vault_tls_kms_key : local.default_kms_key
   lb_ip             = local.use_external_lb ? google_compute_forwarding_rule.external[0].ip_address : google_compute_address.vault_ilb[0].address
+  api_addr          = var.domain != "" ? "https://${var.domain}:${var.vault_port}" : "https://${local.lb_ip}:${var.vault_port}"
 }
 
 # Configure the Google provider, locking to the 2.0 series.
@@ -158,6 +159,7 @@ data "template_file" "vault-config" {
     kms_keyring                              = google_kms_key_ring.vault.name
     kms_crypto_key                           = google_kms_crypto_key.vault-init.name
     lb_ip                                    = local.lb_ip
+    api_addr                                 = local.api_addr
     storage_bucket                           = google_storage_bucket.vault.name
     vault_log_level                          = var.vault_log_level
     vault_port                               = var.vault_port

--- a/scripts/config.hcl.tpl
+++ b/scripts/config.hcl.tpl
@@ -1,6 +1,6 @@
 # Run Vault in HA mode. Even if there's only one Vault node, it doesn't hurt to
 # have this set.
-api_addr = "https://${lb_ip}:${vault_port}"
+api_addr = "${api_addr}"
 cluster_addr = "https://LOCAL_IP:8201"
 
 # Set debugging level
@@ -8,6 +8,9 @@ log_level = "${vault_log_level}"
 
 # Enable the UI
 ui = ${vault_ui_enabled == "true" ? true : false}
+
+# Enable plugin directory
+plugin_directory = "/etc/vault.d/plugins"
 
 # Enable auto-unsealing with Google Cloud KMS
 seal "gcpckms" {

--- a/scripts/startup.sh.tpl
+++ b/scripts/startup.sh.tpl
@@ -42,6 +42,7 @@ useradd -d /etc/vault.d -s /bin/false vault
 
 # Vault config
 mkdir -p /etc/vault.d
+mkdir /etc/vault.d/plugins
 cat <<"EOF" > /etc/vault.d/config.hcl
 ${config}
 EOF
@@ -81,6 +82,10 @@ mkdir -p /var/log/vault
 touch /var/log/vault/{audit,server}.log
 chmod 0640 /var/log/vault/{audit,server}.log
 chown -R vault:adm /var/log/vault
+
+# Add the TLS ca.crt to the trusted store so plugins dont error with TLS handshakes
+cp /etc/vault.d/tls/ca.crt /usr/local/share/ca-certificates/
+update-ca-certificates
 
 # Systemd service
 cat <<"EOF" > /etc/systemd/system/vault.service

--- a/variables.tf
+++ b/variables.tf
@@ -378,6 +378,11 @@ variable "tls_cn" {
   default     = "vault.example.net"
 }
 
+variable "domain" {
+  description = "The domain name that will be set in the api_addr. Load Balancer IP used by default"
+  type        = string
+  default     = ""
+}
 variable "tls_dns_names" {
   description = "List of DNS names added to the Vault server self-signed certificate"
   type        = list(string)


### PR DESCRIPTION
* Make sure api_addr can be a domiain instead of just the LB IP in the case where someone passes in their own TLS certs and the LB IP isn't known until after the cert is created. Typically internal certs don't pin to IP addresses so we should allow the API address to call the domain or else the cert won't be valid
* Add plugin directory in case users want to add a custom plugin
* Add TLS cert to Vault host's trusted store so it can call itself via `api_addr` when it needs to communicate with the plugin.