### PR TITLE
Support service_label for internal load balancer

### DIFF
--- a/README.md
+++ b/README.md
@@ -190,6 +190,7 @@ done
 | service\_account\_project\_additional\_iam\_roles | List of custom IAM roles to add to the project. | list(string) | `<list>` | no |
 | service\_account\_project\_iam\_roles | List of IAM roles for the Vault admin service account to function. If you need to add additional roles, update `service_account_project_additional_iam_roles` instead. | list(string) | `<list>` | no |
 | service\_account\_storage\_bucket\_iam\_roles | List of IAM roles for the Vault admin service account to have on the storage bucket. | list(string) | `<list>` | no |
+| service\_label | The service label to set on the internal load balancer. If not empty, this enables internal DNS for internal load balancers. By default, the service label is disabled. This has no effect on external load balancers. | string | `"null"` | no |
 | ssh\_allowed\_cidrs | List of CIDR blocks to allow access to SSH into nodes. | list(string) | `<list>` | no |
 | storage\_bucket\_class | Type of data storage to use. If you change this value, you will also need to choose a storage_bucket_location which matches this parameter type | string | `"MULTI_REGIONAL"` | no |
 | storage\_bucket\_enable\_versioning | Set to true to enable object versioning in the GCS bucket.. You may want to define lifecycle rules if you want a finite number of old versions. | string | `"false"` | no |

--- a/main.tf
+++ b/main.tf
@@ -55,6 +55,7 @@ module "cluster" {
   source                                       = "./modules/cluster"
   ip_address                                   = local.ip_address
   subnet                                       = local.subnet
+  service_label                                = var.service_label
   project_id                                   = var.project_id
   region                                       = var.region
   vault_storage_bucket                         = google_storage_bucket.vault.name

--- a/modules/cluster/README.md
+++ b/modules/cluster/README.md
@@ -45,6 +45,7 @@ module "vault_cluster" {
 | service\_account\_project\_additional\_iam\_roles | List of custom IAM roles to add to the project. | list(string) | `<list>` | no |
 | service\_account\_project\_iam\_roles | List of IAM roles for the Vault admin service account to function. If you need to add additional roles, update `service_account_project_additional_iam_roles` instead. | list(string) | `<list>` | no |
 | service\_account\_storage\_bucket\_iam\_roles | List of IAM roles for the Vault admin service account to have on the storage bucket. | list(string) | `<list>` | no |
+| service\_label | The service label to set on the internal load balancer. If not empty, this enables internal DNS for internal load balancers. By default, the service label is disabled. This has no effect on external load balancers. | string | `"null"` | no |
 | subnet | The self link of the VPC subnetwork for Vault. By default, one will be created for you. | string | n/a | yes |
 | tls\_ca\_subject | The `subject` block for the root CA certificate. | object | `<map>` | no |
 | tls\_cn | The TLS Common Name for the TLS certificates | string | `"vault.example.net"` | no |

--- a/modules/cluster/main.tf
+++ b/modules/cluster/main.tf
@@ -118,6 +118,7 @@ resource "google_compute_forwarding_rule" "vault_internal" {
   network_tier          = "PREMIUM"
   allow_global_access   = true
   subnetwork            = var.subnet
+  service_label         = var.service_label
 
   backend_service = google_compute_region_backend_service.vault_internal[0].self_link
   ports           = [var.vault_port]

--- a/modules/cluster/variables.tf
+++ b/modules/cluster/variables.tf
@@ -44,6 +44,12 @@ variable "ip_address" {
   description = "The IP address to assign the forwarding rules to."
 }
 
+variable "service_label" {
+  type        = string
+  description = "The service label to set on the internal load balancer. If not empty, this enables internal DNS for internal load balancers. By default, the service label is disabled. This has no effect on external load balancers."
+  default     = null
+}
+
 variable "vault_storage_bucket" {
   type        = string
   description = "Storage bucket name where the backend is configured. This bucket will not be created in this module"

--- a/variables.tf
+++ b/variables.tf
@@ -201,6 +201,12 @@ variable "subnet" {
   description = "The self link of the VPC subnetwork for Vault. By default, one will be created for you."
 }
 
+variable "service_label" {
+  type        = string
+  description = "The service label to set on the internal load balancer. If not empty, this enables internal DNS for internal load balancers. By default, the service label is disabled. This has no effect on external load balancers."
+  default     = null
+}
+
 variable "allow_public_egress" {
   type    = bool
   default = true


### PR DESCRIPTION
Adds a `service_label` variable to the cluster and root modules.

Fixes #105 