### PR TITLE
fix ip_address error when destroying

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -18,7 +18,7 @@ locals {
   lb_scheme       = upper(var.load_balancing_scheme)
   use_internal_lb = local.lb_scheme == "INTERNAL"
   use_external_lb = local.lb_scheme == "EXTERNAL"
-  ip_address      = local.use_internal_lb ? google_compute_address.vault_ilb[0].address : google_compute_address.vault[0].address
+  ip_address      = local.use_internal_lb ? try(google_compute_address.vault_ilb[0].address, "") : try(google_compute_address.vault[0].address, "")
 }
 
 # Configure the Google provider.

--- a/variables.tf
+++ b/variables.tf
@@ -106,7 +106,7 @@ variable "storage_bucket_lifecycle_rules" {
 }
 
 variable "storage_bucket_force_destroy" {
-  type    = string
+  type    = bool
   default = false
 
   description = "Set to true to force deletion of backend bucket on `terraform destroy`"


### PR DESCRIPTION
1- When an interrupted destroy happens, there is a deadlock condition to resolve "ip_address" value, it happens because either 'google_compute_address.vault_ilb' or 'google_compute_address.vault' was already destroyed then this resource at the position 0 does not exist, locking any terraform execution from this state.

2- minor type fix for storage_bucket_force_destroy variable