### PR TITLE
Enable auto-healing, update to Debian 10

### DIFF
--- a/README.md
+++ b/README.md
@@ -209,12 +209,12 @@ done
 | vault\_allowed\_cidrs | List of CIDR blocks to allow access to the Vault nodes. Since the load balancer is a pass-through load balancer, this must also include all IPs from which you will access Vault. The default is unrestricted (any IP address can access Vault). It is recommended that you reduce this to a smaller list. | list(string) | `<list>` | no |
 | vault\_args | Additional command line arguments passed to Vault server | string | `""` | no |
 | vault\_ca\_cert\_filename | GCS object path within the vault_tls_bucket. This is the root CA certificate. | string | `"ca.crt"` | no |
-| vault\_instance\_base\_image | Base operating system image in which to install Vault. This must be a Debian-based system at the moment due to how the metadata startup script runs. | string | `"debian-cloud/debian-9"` | no |
+| vault\_instance\_base\_image | Base operating system image in which to install Vault. This must be a Debian-based system at the moment due to how the metadata startup script runs. | string | `"debian-cloud/debian-10"` | no |
 | vault\_instance\_labels | Labels to apply to the Vault instances. | map(string) | `<map>` | no |
 | vault\_instance\_metadata | Additional metadata to add to the Vault instances. | map(string) | `<map>` | no |
 | vault\_instance\_tags | Additional tags to apply to the instances. Note 'allow-ssh' and 'allow-vault' will be present on all instances. | list(string) | `<list>` | no |
 | vault\_log\_level | Log level to run Vault in. See the Vault documentation for valid values. | string | `"warn"` | no |
-| vault\_machine\_type | Machine type to use for Vault instances. | string | `"n1-standard-1"` | no |
+| vault\_machine\_type | Machine type to use for Vault instances. | string | `"e2-standard-2"` | no |
 | vault\_max\_num\_servers | Maximum number of Vault server nodes to run at one time. The group will not autoscale beyond this number. | string | `"7"` | no |
 | vault\_min\_num\_servers | Minimum number of Vault server nodes in the autoscaling group. The group will not have less than this number of nodes. | string | `"1"` | no |
 | vault\_port | Numeric port on which to run and expose Vault. | string | `"8200"` | no |
@@ -227,7 +227,7 @@ done
 | vault\_tls\_kms\_key\_project | Project ID where the KMS key is stored. By default, same as `project_id` | string | `""` | no |
 | vault\_tls\_require\_and\_verify\_client\_cert | Always use client certificates. You may want to disable this if users will not be authenticating to Vault with client certificates. | string | `"false"` | no |
 | vault\_ui\_enabled | Controls whether the Vault UI is enabled and accessible. | string | `"true"` | no |
-| vault\_version | Version of vault to install. This version must be 1.0+ and must be published on the HashiCorp releases service. | string | `"1.1.3"` | no |
+| vault\_version | Version of vault to install. This version must be 1.0+ and must be published on the HashiCorp releases service. | string | `"1.6.0"` | no |
 
 ## Outputs
 

--- a/modules/cluster/README.md
+++ b/modules/cluster/README.md
@@ -32,6 +32,7 @@ module "vault_cluster" {
 | Name | Description | Type | Default | Required |
 |------|-------------|:----:|:-----:|:-----:|
 | domain | The domain name that will be set in the api_addr. Load Balancer IP used by default | string | `""` | no |
+| hc\_initial\_delay\_secs | The number of seconds that the managed instance group waits before it applies autohealing policies to new instances or recently recreated instances. | number | `"60"` | no |
 | host\_project\_id | ID of the host project if using Shared VPC | string | `""` | no |
 | http\_proxy | HTTP proxy for downloading agents and vault executable on startup. Only necessary if allow_public_egress is false. This is only used on the first startup of the Vault cluster and will NOT set the global HTTP_PROXY environment variable. i.e. If you configure Vault to manage credentials for other services, default HTTP routes will be taken. | string | `""` | no |
 | ip\_address | The IP address to assign the forwarding rules to. | string | n/a | yes |
@@ -40,6 +41,7 @@ module "vault_cluster" {
 | kms\_protection\_level | The protection level to use for the KMS crypto key. | string | `"software"` | no |
 | load\_balancing\_scheme | Options are INTERNAL or EXTERNAL. If `EXTERNAL`, the forwarding rule will be of type EXTERNAL and a public IP will be created. If `INTERNAL` the type will be INTERNAL and a random RFC 1918 private IP will be assigned | string | `"EXTERNAL"` | no |
 | manage\_tls | Set to `false` if you'd like to manage and upload your own TLS files. See `Managing TLS` for more details | bool | `"true"` | no |
+| min\_ready\_sec | Minimum number of seconds to wait before considering a new or restarted instance as updated. This value must be from range. [0,3600] | number | `"0"` | no |
 | project\_id | ID of the project in which to create resources and add IAM bindings. | string | n/a | yes |
 | region | Region in which to create resources. | string | `"us-east4"` | no |
 | service\_account\_project\_additional\_iam\_roles | List of custom IAM roles to add to the project. | list(string) | `<list>` | no |
@@ -56,12 +58,12 @@ module "vault_cluster" {
 | user\_startup\_script | Additional user-provided code injected after Vault is setup | string | `""` | no |
 | vault\_args | Additional command line arguments passed to Vault server | string | `""` | no |
 | vault\_ca\_cert\_filename | GCS object path within the vault_tls_bucket. This is the root CA certificate. | string | `"ca.crt"` | no |
-| vault\_instance\_base\_image | Base operating system image in which to install Vault. This must be a Debian-based system at the moment due to how the metadata startup script runs. | string | `"debian-cloud/debian-9"` | no |
+| vault\_instance\_base\_image | Base operating system image in which to install Vault. This must be a Debian-based system at the moment due to how the metadata startup script runs. | string | `"debian-cloud/debian-10"` | no |
 | vault\_instance\_labels | Labels to apply to the Vault instances. | map(string) | `<map>` | no |
 | vault\_instance\_metadata | Additional metadata to add to the Vault instances. | map(string) | `<map>` | no |
 | vault\_instance\_tags | Additional tags to apply to the instances. Note 'allow-ssh' and 'allow-vault' will be present on all instances. | list(string) | `<list>` | no |
 | vault\_log\_level | Log level to run Vault in. See the Vault documentation for valid values. | string | `"warn"` | no |
-| vault\_machine\_type | Machine type to use for Vault instances. | string | `"n1-standard-1"` | no |
+| vault\_machine\_type | Machine type to use for Vault instances. | string | `"e2-standard-2"` | no |
 | vault\_max\_num\_servers | Maximum number of Vault server nodes to run at one time. The group will not autoscale beyond this number. | string | `"7"` | no |
 | vault\_min\_num\_servers | Minimum number of Vault server nodes in the autoscaling group. The group will not have less than this number of nodes. | string | `"1"` | no |
 | vault\_port | Numeric port on which to run and expose Vault. | string | `"8200"` | no |
@@ -76,7 +78,8 @@ module "vault_cluster" {
 | vault\_tls\_kms\_key\_project | Project ID where the KMS key is stored. By default, same as `project_id` | string | `""` | no |
 | vault\_tls\_require\_and\_verify\_client\_cert | Always use client certificates. You may want to disable this if users will not be authenticating to Vault with client certificates. | string | `"false"` | no |
 | vault\_ui\_enabled | Controls whether the Vault UI is enabled and accessible. | string | `"true"` | no |
-| vault\_version | Version of vault to install. This version must be 1.0+ and must be published on the HashiCorp releases service. | string | `"1.1.3"` | no |
+| vault\_version | Version of vault to install. This version must be 1.0+ and must be published on the HashiCorp releases service. | string | `"1.6.0"` | no |
+| zones | The zones to distribute instances across.  If empty, all zones in the region are used.  ['us-west1-a', 'us-west1-b', 'us-west1-c'] | list(string) | `<list>` | no |
 
 ## Outputs
 

--- a/modules/cluster/startup.tf
+++ b/modules/cluster/startup.tf
@@ -52,6 +52,7 @@ data "template_file" "vault-config" {
     storage_bucket                           = var.vault_storage_bucket
     vault_log_level                          = var.vault_log_level
     vault_port                               = var.vault_port
+    vault_proxy_port                         = var.vault_proxy_port
     vault_tls_disable_client_certs           = var.vault_tls_disable_client_certs
     vault_tls_require_and_verify_client_cert = var.vault_tls_require_and_verify_client_cert
     vault_ui_enabled                         = var.vault_ui_enabled

--- a/modules/cluster/variables.tf
+++ b/modules/cluster/variables.tf
@@ -156,7 +156,7 @@ variable "vault_instance_metadata" {
 
 variable "vault_instance_base_image" {
   type    = string
-  default = "debian-cloud/debian-9"
+  default = "debian-cloud/debian-10"
 
   description = "Base operating system image in which to install Vault. This must be a Debian-based system at the moment due to how the metadata startup script runs."
 }
@@ -184,10 +184,9 @@ variable "vault_min_num_servers" {
 
 variable "vault_machine_type" {
   type    = string
-  default = "n1-standard-1"
+  default = "e2-standard-2"
 
   description = "Machine type to use for Vault instances."
-
 }
 
 variable "vault_max_num_servers" {
@@ -270,7 +269,7 @@ variable "vault_ui_enabled" {
 
 variable "vault_version" {
   type    = string
-  default = "1.1.3"
+  default = "1.6.0"
 
   description = "Version of vault to install. This version must be 1.0+ and must be published on the HashiCorp releases service."
 
@@ -288,6 +287,24 @@ variable "user_startup_script" {
   default = ""
 
   description = "Additional user-provided code injected after Vault is setup"
+}
+
+variable "min_ready_sec" {
+  description = "Minimum number of seconds to wait before considering a new or restarted instance as updated. This value must be from range. [0,3600]"
+  type        = number
+  default     = 0
+}
+
+variable "hc_initial_delay_secs" {
+  description = "The number of seconds that the managed instance group waits before it applies autohealing policies to new instances or recently recreated instances."
+  type        = number
+  default     = 60
+}
+
+variable "zones" {
+  description = "The zones to distribute instances across.  If empty, all zones in the region are used.  ['us-west1-a', 'us-west1-b', 'us-west1-c']"
+  type        = list(string)
+  default     = []
 }
 
 #

--- a/test/integration/helpers/shared_tests/shared_instance_group_tests.rb
+++ b/test/integration/helpers/shared_tests/shared_instance_group_tests.rb
@@ -1,0 +1,107 @@
+# Copyright 2020 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+RSpec.shared_examples "instance_group_behavior" do |params|
+  project_id = params[:project_id]
+  region     = params[:region] || 'us-east4'
+  ig_name    = params[:ig_name] || 'vault-igm'
+  deadline   = params[:deadline] || 300
+
+  ##
+  # Wait until an instance has booted
+  def wait_for_boot(project_id, instance)
+    tries=60
+    delay=5
+    while tries > 0
+      c = command("gcloud --project=#{project_id} compute instances get-serial-port-output #{instance}")
+      if c.stdout =~ /GCEMetadataScripts: Finished running startup scripts/
+        return c.stdout
+      end
+      tries = tries - 1
+      sleep(delay)
+    end
+    return c.stdout
+  end
+
+  ##
+  # Wait until an instance has currentAction: "NONE" (STAGING => VERIFYING => NONE)
+  def wait_for_action(project_id, ig_name, region)
+    tries=60
+    delay=5
+    instances = []
+    while tries > 0
+      list = command("gcloud --project=#{project_id} compute instance-groups managed list-instances #{ig_name} --region=#{region} --format=json")
+      instances = list.exit_status == 0 ? JSON.parse(list.stdout) : []
+      if instances.all? { |i| i['currentAction'] == 'NONE' }
+        return instances
+      end
+      tries = tries - 1
+      sleep(delay)
+    end
+    return list
+  end
+
+  describe "instances" do
+    # Wait until the instance group is stable, otherwise the instance status is
+    # in flux, for example could be "STAGING" or "RUNNING" depending on the
+    # health check.  DEADLINE seconds is intentional to provide quick feedback
+    # to the contributor and to ensure the instance recovers quickly when
+    # unhealthy.  The startup script should strive to get the health check
+    # passing as quickly as possible.
+    before :all do
+      # Note, this block intentionally uses the unconventional before :all form
+      # and instance variables because the API calls are time consuming and we
+      # need the data only once to assert against it.
+      @wait = command("gcloud --project=#{project_id} compute instance-groups managed wait-until --stable --timeout=#{deadline} #{ig_name} --region=#{region}")
+      # Wait until there are no actions on each instance
+      @instances = wait_for_action(project_id, ig_name, region)
+      # Array<String> serial port output from each instance in the group.
+      @consoles = @instances.collect {|i| wait_for_boot(project_id, i['instance']) }
+    end
+
+    it "should become stable in #{deadline} seconds" do
+      expect(@wait.exit_status).to eq(0)
+      expect(@wait.stdout).to include("Group is stable")
+    end
+
+    it 'should at least one instance in the group' do
+      expect(@instances).not_to be_empty
+    end
+
+    it 'should be running' do
+      @instances.each do |inst|
+        expect(inst['instanceStatus']).to eq("RUNNING"), "expected all to be RUNNING, got #{@instances.inspect}"
+      end
+    end
+
+    it 'should be healthy' do
+      @instances.each do |inst|
+        health_states = inst['instanceHealth'].collect do |h|
+          h['detailedHealthState']
+        end
+        expect(health_states).to all(eq("HEALTHY")), "expected #{inst.inspect} to have all instanceHealth detailedHealthState HEALTHY values."
+      end
+    end
+
+    # This example is intended to help troubleshoot startup failures by giving
+    # visibility into the startup script output directly in the build output
+    # log.
+    it 'should run startup scripts successfully with exit status 0' do
+      expect(@consoles).not_to be_empty
+      @consoles.each do |serial_console|
+        expect(serial_console).to include('startup-script exit status 0')
+      end
+    end
+  end
+end

--- a/test/integration/shared_vpc_internal/controls/default.rb
+++ b/test/integration/shared_vpc_internal/controls/default.rb
@@ -12,8 +12,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 require 'json'
+require_relative '../../helpers/shared_tests/shared_instance_group_tests'
 
 LB_NAME = 'vault-internal'
+IG_NAME = 'vault-igm'
 REGION = 'us-west1'
 
 project_id = attribute('project_id')
@@ -31,17 +33,8 @@ control "Vault" do
     end
   end
 
-  describe "Instance configuration" do
-    subject { command("gcloud --project=#{project_id} compute instances list --format=json") }
-    its(:exit_status) { should eq 0 }
-    its(:stderr) { should eq '' }
-    let!(:data) { JSON.parse(subject.stdout) if subject.exit_status == 0 }
-
-    it 'should be running' do
-      data.each do |inst|
-        expect(inst['name']).to start_with("vault")
-        expect(inst['status']).to eq("RUNNING")
-      end
-    end
+  describe "Managed instances" do
+    include_examples "instance_group_behavior", project_id: project_id, region: REGION, ig_name: IG_NAME
   end
 end
+

--- a/test/setup/variables.tf
+++ b/test/setup/variables.tf
@@ -27,7 +27,7 @@ variable "billing_account" {
 
 variable "network_name" {
   description = "Vault shared VPC network name."
-  default     = "vault-spvc"
+  default     = "vault-svpc"
 }
 
 variable "subnet_region" {

--- a/variables.tf
+++ b/variables.tf
@@ -370,7 +370,7 @@ variable "vault_instance_metadata" {
 
 variable "vault_instance_base_image" {
   type    = string
-  default = "debian-cloud/debian-9"
+  default = "debian-cloud/debian-10"
 
   description = "Base operating system image in which to install Vault. This must be a Debian-based system at the moment due to how the metadata startup script runs."
 }
@@ -398,7 +398,7 @@ variable "vault_min_num_servers" {
 
 variable "vault_machine_type" {
   type    = string
-  default = "n1-standard-1"
+  default = "e2-standard-2"
 
   description = "Machine type to use for Vault instances."
 
@@ -484,7 +484,7 @@ variable "vault_ui_enabled" {
 
 variable "vault_version" {
   type    = string
-  default = "1.1.3"
+  default = "1.6.0"
 
   description = "Version of vault to install. This version must be 1.0+ and must be published on the HashiCorp releases service."
 


### PR DESCRIPTION
This patch adds an auto-healing policy to automatically re-create the
vault cluster instance if the vault server stops.  One of the nodes in
the instance group is active as per [Vault HA][ha].  The other nodes are
passive and forward requests to the active node.  Two different health
checks are used because passive nodes return non-200 status codes by
default.

In addition, this patch:

 * Update Vault to 1.6.0 by default
 * Update image to Debian 10 by default
 * Defaults to e2-standard-2 instance types, which are less expensive
   and more performant than n1-standard-1.
 * Improves startup (and auto-heal recovery) time by starting the vault
   service as quickly as possible in the startup-script.

[ha]: https://www.vaultproject.io/docs/concepts/ha.html