### PR TITLE
Update TLS to use v3.3 which includes support for linux_arm64

### DIFF
--- a/modules/cluster/crypto.tf
+++ b/modules/cluster/crypto.tf
@@ -53,7 +53,6 @@ resource "tls_private_key" "root" {
 resource "tls_self_signed_cert" "root" {
   count = local.manage_tls_count
 
-  key_algorithm   = tls_private_key.root[0].algorithm
   private_key_pem = tls_private_key.root[0].private_key_pem
 
   subject {
@@ -94,7 +93,6 @@ resource "tls_private_key" "vault-server" {
 resource "tls_cert_request" "vault-server" {
   count = local.manage_tls_count
 
-  key_algorithm   = tls_private_key.vault-server[0].algorithm
   private_key_pem = tls_private_key.vault-server[0].private_key_pem
 
   dns_names = var.tls_dns_names
@@ -113,7 +111,6 @@ resource "tls_locally_signed_cert" "vault-server" {
   count = local.manage_tls_count
 
   cert_request_pem   = tls_cert_request.vault-server[0].cert_request_pem
-  ca_key_algorithm   = tls_private_key.root[0].algorithm
   ca_private_key_pem = tls_private_key.root[0].private_key_pem
   ca_cert_pem        = tls_self_signed_cert.root[0].cert_pem
 

--- a/modules/cluster/versions.tf
+++ b/modules/cluster/versions.tf
@@ -20,7 +20,7 @@ terraform {
 
     tls = {
       source  = "hashicorp/tls"
-      version = "~> 2.1"
+      version = "~> 3.3"
     }
 
     google = {

--- a/network.tf
+++ b/network.tf
@@ -38,6 +38,8 @@ resource "google_compute_address" "vault_ilb" {
   subnetwork   = local.subnet
   name         = "vault-ilb"
   address_type = "INTERNAL"
+  project = var.project_id
+  region  = var.region
 
   depends_on = [google_project_service.service]
 }

--- a/network.tf
+++ b/network.tf
@@ -38,8 +38,8 @@ resource "google_compute_address" "vault_ilb" {
   subnetwork   = local.subnet
   name         = "vault-ilb"
   address_type = "INTERNAL"
-  project = var.project_id
-  region  = var.region
+  project      = var.project_id
+  region       = var.region
 
   depends_on = [google_project_service.service]
 }


### PR DESCRIPTION
Minor Changes

- Update the TLS required version to `version = "~> 3.3"`
- Removed deprieciated inputs in `crypto.tf` that are now inferred from the key.
- Add missing Project and Region inputs to the `network.tf` resource `google_compute_address.vault_ilb`