### PR TITLE
feat: allow tls_save_ca_to_disk to also chose the filename of the full path of the local CA public certificate copy

### DIFF
--- a/README.md
+++ b/README.md
@@ -205,6 +205,7 @@ done
 | tls\_ips | List of IP addresses added to the Vault server self-signed certificate | `list(string)` | <pre>[<br>  "127.0.0.1"<br>]</pre> | no |
 | tls\_ou | The TLS Organizational Unit for the TLS certificate | `string` | `"IT Security Operations"` | no |
 | tls\_save\_ca\_to\_disk | Save the CA public certificate on the local filesystem. The CA is always stored in GCS, but this option also saves it to the filesystem. | `bool` | `true` | no |
+| tls\_save\_ca\_to\_disk\_filename | The filename or full path to save the CA public certificate on the local filesystem. Ony applicable if `tls_save_ca_to_disk` is set to `true`. | `string` | `"ca.crt"` | no |
 | user\_startup\_script | Additional user-provided code injected after Vault is setup | `string` | `""` | no |
 | vault\_allowed\_cidrs | List of CIDR blocks to allow access to the Vault nodes. Since the load balancer is a pass-through load balancer, this must also include all IPs from which you will access Vault. The default is unrestricted (any IP address can access Vault). It is recommended that you reduce this to a smaller list. | `list(string)` | <pre>[<br>  "0.0.0.0/0"<br>]</pre> | no |
 | vault\_args | Additional command line arguments passed to Vault server | `string` | `""` | no |

--- a/main.tf
+++ b/main.tf
@@ -88,5 +88,6 @@ module "cluster" {
   tls_dns_names                                = var.tls_dns_names
   tls_ips                                      = var.tls_ips
   tls_save_ca_to_disk                          = var.tls_save_ca_to_disk
+  tls_save_ca_to_disk_filename                 = var.tls_save_ca_to_disk_filename
   tls_ou                                       = var.tls_ou
 }

--- a/modules/cluster/README.md
+++ b/modules/cluster/README.md
@@ -55,6 +55,7 @@ module "vault_cluster" {
 | tls\_ips | List of IP addresses added to the Vault server self-signed certificate | `list(string)` | <pre>[<br>  "127.0.0.1"<br>]</pre> | no |
 | tls\_ou | The TLS Organizational Unit for the TLS certificate | `string` | `"IT Security Operations"` | no |
 | tls\_save\_ca\_to\_disk | Save the CA public certificate on the local filesystem. The CA is always stored in GCS, but this option also saves it to the filesystem. | `bool` | `true` | no |
+| tls\_save\_ca\_to\_disk\_filename | The filename or full path to save the CA public certificate on the local filesystem. Ony applicable if `tls_save_ca_to_disk` is set to `true`. | `string` | `"ca.crt"` | no |
 | user\_startup\_script | Additional user-provided code injected after Vault is setup | `string` | `""` | no |
 | vault\_args | Additional command line arguments passed to Vault server | `string` | `""` | no |
 | vault\_ca\_cert\_filename | GCS object path within the vault\_tls\_bucket. This is the root CA certificate. | `string` | `"ca.crt"` | no |

--- a/modules/cluster/crypto.tf
+++ b/modules/cluster/crypto.tf
@@ -77,7 +77,7 @@ resource "tls_self_signed_cert" "root" {
 resource "local_file" "root" {
   count = min(local.manage_tls_count, local.tls_save_ca_to_disk_count)
 
-  filename = "ca.crt"
+  filename = var.tls_save_ca_to_disk_filename
   content  = tls_self_signed_cert.root[0].cert_pem
 }
 

--- a/modules/cluster/variables.tf
+++ b/modules/cluster/variables.tf
@@ -380,6 +380,13 @@ variable "tls_save_ca_to_disk" {
   description = "Save the CA public certificate on the local filesystem. The CA is always stored in GCS, but this option also saves it to the filesystem."
 }
 
+variable "tls_save_ca_to_disk_filename" {
+  type    = string
+  default = "ca.crt"
+
+  description = "The filename or full path to save the CA public certificate on the local filesystem. Ony applicable if `tls_save_ca_to_disk` is set to `true`."
+}
+
 variable "tls_ou" {
   description = "The TLS Organizational Unit for the TLS certificate"
   default     = "IT Security Operations"

--- a/variables.tf
+++ b/variables.tf
@@ -322,6 +322,13 @@ variable "tls_save_ca_to_disk" {
   description = "Save the CA public certificate on the local filesystem. The CA is always stored in GCS, but this option also saves it to the filesystem."
 }
 
+variable "tls_save_ca_to_disk_filename" {
+  type    = string
+  default = "ca.crt"
+
+  description = "The filename or full path to save the CA public certificate on the local filesystem. Ony applicable if `tls_save_ca_to_disk` is set to `true`."
+}
+
 variable "tls_ou" {
   description = "The TLS Organizational Unit for the TLS certificate"
   default     = "IT Security Operations"


### PR DESCRIPTION
Fixes https://github.com/terraform-google-modules/terraform-google-vault/issues/164