### PR TITLE
fix(TPG >= 4.53)!: set bgp keepalive_interval to default 20

### DIFF
--- a/network.tf
+++ b/network.tf
@@ -53,7 +53,7 @@ resource "google_compute_router" "vault-router" {
 
   bgp {
     asn = 64514
-    bgp = 20
+    keepalive_interval = 20
   }
 
   depends_on = [google_project_service.service]

--- a/network.tf
+++ b/network.tf
@@ -52,7 +52,7 @@ resource "google_compute_router" "vault-router" {
   network = local.network
 
   bgp {
-    asn = 64514
+    asn                = 64514
     keepalive_interval = 20
   }
 

--- a/network.tf
+++ b/network.tf
@@ -53,6 +53,7 @@ resource "google_compute_router" "vault-router" {
 
   bgp {
     asn = 64514
+    bgp = 20
   }
 
   depends_on = [google_project_service.service]

--- a/versions.tf
+++ b/versions.tf
@@ -20,7 +20,7 @@ terraform {
 
     google = {
       source  = "hashicorp/google"
-      version = ">= 3.53, < 5.0"
+      version = ">= 4.53, < 5.0"
     }
   }
 


### PR DESCRIPTION
issue: https://github.com/terraform-google-modules/terraform-google-vault/issues/171
---
`keepalive_interval` is not set and this value needs to be between 20 and 60.

> If set, this value must be between 20 and 60. The default is 20.

[Provider documentation](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/compute_router#keepalive_interval)

As this is not set, every time we run `terraform plan`, the plan outputs this change and it is quite noisy.

![image](https://user-images.githubusercontent.com/13359249/218437795-62544c00-7381-4bf0-a5d1-940e18d26828.png)
