### PR TITLE
feat: support shared VPC with allow_public_egress

### DIFF
--- a/README.md
+++ b/README.md
@@ -208,6 +208,7 @@ done
 | tls\_save\_ca\_to\_disk | Save the CA public certificate on the local filesystem. The CA is always stored in GCS, but this option also saves it to the filesystem. | `bool` | `true` | no |
 | tls\_save\_ca\_to\_disk\_filename | The filename or full path to save the CA public certificate on the local filesystem. Ony applicable if `tls_save_ca_to_disk` is set to `true`. | `string` | `"ca.crt"` | no |
 | user\_startup\_script | Additional user-provided code injected after Vault is setup | `string` | `""` | no |
+| user\_vault\_config | Additional user-provided vault config added at the end of standard vault config | `string` | `""` | no |
 | vault\_allowed\_cidrs | List of CIDR blocks to allow access to the Vault nodes. Since the load balancer is a pass-through load balancer, this must also include all IPs from which you will access Vault. The default is unrestricted (any IP address can access Vault). It is recommended that you reduce this to a smaller list. | `list(string)` | <pre>[<br>  "0.0.0.0/0"<br>]</pre> | no |
 | vault\_args | Additional command line arguments passed to Vault server | `string` | `""` | no |
 | vault\_ca\_cert\_filename | GCS object path within the vault\_tls\_bucket. This is the root CA certificate. | `string` | `"ca.crt"` | no |

--- a/README.md
+++ b/README.md
@@ -175,6 +175,7 @@ done
 | allow\_public\_egress | Whether to create a NAT for external egress. If false, you must also specify an `http_proxy` to download required executables including Vault, Fluentd and Stackdriver | `bool` | `true` | no |
 | allow\_ssh | Allow external access to ssh port 22 on the Vault VMs. It is a best practice to set this to false, however it is true by default for the sake of backwards compatibility. | `bool` | `true` | no |
 | domain | The domain name that will be set in the api\_addr. Load Balancer IP used by default | `string` | `""` | no |
+| host\_project\_id | The project id of the shared VPC host project, when deploying into a shared VPC | `string` | `""` | no |
 | http\_proxy | HTTP proxy for downloading agents and vault executable on startup. Only necessary if allow\_public\_egress is false. This is only used on the first startup of the Vault cluster and will NOT set the global HTTP\_PROXY environment variable. i.e. If you configure Vault to manage credentials for other services, default HTTP routes will be taken. | `string` | `""` | no |
 | kms\_crypto\_key | The name of the Cloud KMS Key used for encrypting initial TLS certificates and for configuring Vault auto-unseal. Terraform will create this key. | `string` | `"vault-init"` | no |
 | kms\_keyring | Name of the Cloud KMS KeyRing for asset encryption. Terraform will create this keyring. | `string` | `"vault"` | no |
@@ -184,7 +185,6 @@ done
 | network | The self link of the VPC network for Vault. By default, one will be created for you. | `string` | `""` | no |
 | network\_subnet\_cidr\_range | CIDR block range for the subnet. | `string` | `"10.127.0.0/20"` | no |
 | project\_id | ID of the project in which to create resources and add IAM bindings. | `string` | n/a | yes |
-| host\_project\_id | ID of the host project for shared VPC when deploying into a shard VPC. | `string` | `""` | no |
 | project\_services | List of services to enable on the project where Vault will run. These services are required in order for this Vault setup to function. | `list(string)` | <pre>[<br>  "cloudkms.googleapis.com",<br>  "cloudresourcemanager.googleapis.com",<br>  "compute.googleapis.com",<br>  "iam.googleapis.com",<br>  "logging.googleapis.com",<br>  "monitoring.googleapis.com"<br>]</pre> | no |
 | region | Region in which to create resources. | `string` | `"us-east4"` | no |
 | service\_account\_name | Name of the Vault service account. | `string` | `"vault-admin"` | no |

--- a/README.md
+++ b/README.md
@@ -184,6 +184,7 @@ done
 | network | The self link of the VPC network for Vault. By default, one will be created for you. | `string` | `""` | no |
 | network\_subnet\_cidr\_range | CIDR block range for the subnet. | `string` | `"10.127.0.0/20"` | no |
 | project\_id | ID of the project in which to create resources and add IAM bindings. | `string` | n/a | yes |
+| host\_project\_id | ID of the host project for shared VPC when deploying into a shard VPC. | `string` | `""` | no |
 | project\_services | List of services to enable on the project where Vault will run. These services are required in order for this Vault setup to function. | `list(string)` | <pre>[<br>  "cloudkms.googleapis.com",<br>  "cloudresourcemanager.googleapis.com",<br>  "compute.googleapis.com",<br>  "iam.googleapis.com",<br>  "logging.googleapis.com",<br>  "monitoring.googleapis.com"<br>]</pre> | no |
 | region | Region in which to create resources. | `string` | `"us-east4"` | no |
 | service\_account\_name | Name of the Vault service account. | `string` | `"vault-admin"` | no |

--- a/main.tf
+++ b/main.tf
@@ -82,6 +82,7 @@ module "cluster" {
   vault_version                                = var.vault_version
   http_proxy                                   = var.http_proxy
   user_startup_script                          = var.user_startup_script
+  user_vault_config                            = var.user_vault_config
   manage_tls                                   = var.manage_tls
   tls_ca_subject                               = var.tls_ca_subject
   tls_cn                                       = var.tls_cn

--- a/main.tf
+++ b/main.tf
@@ -48,6 +48,7 @@ module "cluster" {
   subnet                                       = local.subnet
   service_label                                = var.service_label
   project_id                                   = var.project_id
+  host_project_id                              = var.host_project_id
   region                                       = var.region
   vault_storage_bucket                         = google_storage_bucket.vault.name
   vault_service_account_email                  = google_service_account.vault-admin.email

--- a/modules/cluster/README.md
+++ b/modules/cluster/README.md
@@ -57,6 +57,7 @@ module "vault_cluster" {
 | tls\_save\_ca\_to\_disk | Save the CA public certificate on the local filesystem. The CA is always stored in GCS, but this option also saves it to the filesystem. | `bool` | `true` | no |
 | tls\_save\_ca\_to\_disk\_filename | The filename or full path to save the CA public certificate on the local filesystem. Ony applicable if `tls_save_ca_to_disk` is set to `true`. | `string` | `"ca.crt"` | no |
 | user\_startup\_script | Additional user-provided code injected after Vault is setup | `string` | `""` | no |
+| user\_vault\_config | Additional user-provided vault config added at the end of standard vault config | `string` | `""` | no |
 | vault\_args | Additional command line arguments passed to Vault server | `string` | `""` | no |
 | vault\_ca\_cert\_filename | GCS object path within the vault\_tls\_bucket. This is the root CA certificate. | `string` | `"ca.crt"` | no |
 | vault\_instance\_base\_image | Base operating system image in which to install Vault. This must be a Debian-based system at the moment due to how the metadata startup script runs. | `string` | `"debian-cloud/debian-10"` | no |

--- a/modules/cluster/main.tf
+++ b/modules/cluster/main.tf
@@ -110,6 +110,7 @@ resource "google_compute_instance_template" "vault" {
               vault_tls_disable_client_certs           = var.vault_tls_disable_client_certs
               vault_tls_require_and_verify_client_cert = var.vault_tls_require_and_verify_client_cert
               vault_ui_enabled                         = var.vault_ui_enabled
+              user_vault_config                        = var.user_vault_config
           })
       })
     },

--- a/modules/cluster/templates/config.hcl.tpl
+++ b/modules/cluster/templates/config.hcl.tpl
@@ -69,3 +69,8 @@ telemetry {
   statsd_address   = "127.0.0.1:8125"
   disable_hostname = true
 }
+
+#########################################
+##          user_vault_config          ##
+#########################################
+${user_vault_config}

--- a/modules/cluster/variables.tf
+++ b/modules/cluster/variables.tf
@@ -289,6 +289,13 @@ variable "user_startup_script" {
   description = "Additional user-provided code injected after Vault is setup"
 }
 
+variable "user_vault_config" {
+  type    = string
+  default = ""
+
+  description = "Additional user-provided vault config added at the end of standard vault config"
+}
+
 variable "vault_update_policy_type" {
   type        = string
   default     = "OPPORTUNISTIC"

--- a/network.tf
+++ b/network.tf
@@ -20,12 +20,13 @@
 locals {
   network = var.network == "" ? google_compute_network.vault-network[0].self_link : var.network
   subnet  = var.subnet == "" ? google_compute_subnetwork.vault-subnet[0].self_link : var.subnet
+  nat_project_id = var.host_project_id == "" ? var.project_id : var.host_project_id
 }
 
 # Address for NATing
 resource "google_compute_address" "vault-nat" {
   count   = var.allow_public_egress ? 2 : 0
-  project = var.project_id
+  project = local.nat_project_id
   name    = "vault-nat-external-${count.index}"
   region  = var.region
 
@@ -47,7 +48,7 @@ resource "google_compute_address" "vault_ilb" {
 resource "google_compute_router" "vault-router" {
   count   = var.allow_public_egress ? 1 : 0
   name    = "vault-router"
-  project = var.project_id
+  project = local.nat_project_id
   region  = var.region
   network = local.network
 
@@ -62,7 +63,7 @@ resource "google_compute_router" "vault-router" {
 resource "google_compute_router_nat" "vault-nat" {
   count   = var.allow_public_egress ? 1 : 0
   name    = "vault-nat-1"
-  project = var.project_id
+  project = local.nat_project_id
   router  = google_compute_router.vault-router[0].name
   region  = var.region
 

--- a/network.tf
+++ b/network.tf
@@ -18,8 +18,8 @@
 # This file contains the networking bits.
 #
 locals {
-  network = var.network == "" ? google_compute_network.vault-network[0].self_link : var.network
-  subnet  = var.subnet == "" ? google_compute_subnetwork.vault-subnet[0].self_link : var.subnet
+  network        = var.network == "" ? google_compute_network.vault-network[0].self_link : var.network
+  subnet         = var.subnet == "" ? google_compute_subnetwork.vault-subnet[0].self_link : var.subnet
   nat_project_id = var.host_project_id == "" ? var.project_id : var.host_project_id
 }
 

--- a/variables.tf
+++ b/variables.tf
@@ -189,6 +189,12 @@ variable "kms_protection_level" {
 # Networking
 # --------------------
 
+variable "host_project_id" {
+  type        = string
+  default     = ""
+  description = "The project id of the shared VPC host project, when deploying into a shared VPC"
+}
+
 variable "network" {
   type        = string
   default     = ""

--- a/variables.tf
+++ b/variables.tf
@@ -516,3 +516,10 @@ variable "user_startup_script" {
 
   description = "Additional user-provided code injected after Vault is setup"
 }
+
+variable "user_vault_config" {
+  type    = string
+  default = ""
+
+  description = "Additional user-provided vault config added at the end of standard vault config"
+}


### PR DESCRIPTION
Closes #173 

When using allow_public_egress with shared VPC the Cloud NAT resources need to be in the host project.  This PR adds that enhancement/fix.  It also fixes the firewall rules in the case of a shared VPC deployment (by creating them in the host project as is necessary in that case)

Also adds a new variable user_vault_config that is appended to the vault config in the config.hcl.tpl template