### PR TITLE
feat: hc_initial_delay_secs as a top level variable 

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -58,6 +58,7 @@ module "cluster" {
   kms_crypto_key                               = var.kms_crypto_key
   kms_protection_level                         = var.kms_protection_level
   load_balancing_scheme                        = var.load_balancing_scheme
+  hc_initial_delay_secs                        = var.hc_initial_delay_secs
   vault_args                                   = var.vault_args
   vault_instance_labels                        = var.vault_instance_labels
   vault_ca_cert_filename                       = var.vault_ca_cert_filename

--- a/variables.tf
+++ b/variables.tf
@@ -242,6 +242,12 @@ variable "load_balancing_scheme" {
   description = "Options are INTERNAL or EXTERNAL. If `EXTERNAL`, the forwarding rule will be of type EXTERNAL and a public IP will be created. If `INTERNAL` the type will be INTERNAL and a random RFC 1918 private IP will be assigned"
 }
 
+variable "hc_initial_delay_secs" {
+  description = "The number of seconds that the managed instance group waits before it applies autohealing policies to new instances or recently recreated instances."
+  type        = number
+  default     = 60
+}
+
 #
 #
 # SSH


### PR DESCRIPTION
Exposes `hc_initial_delay_secs` variable from child module to the main module.