### PR TITLE
fix!: update default image to Debian 11

### DIFF
--- a/README.md
+++ b/README.md
@@ -212,7 +212,7 @@ done
 | vault\_allowed\_cidrs | List of CIDR blocks to allow access to the Vault nodes. Since the load balancer is a pass-through load balancer, this must also include all IPs from which you will access Vault. The default is unrestricted (any IP address can access Vault). It is recommended that you reduce this to a smaller list. | `list(string)` | <pre>[<br>  "0.0.0.0/0"<br>]</pre> | no |
 | vault\_args | Additional command line arguments passed to Vault server | `string` | `""` | no |
 | vault\_ca\_cert\_filename | GCS object path within the vault\_tls\_bucket. This is the root CA certificate. | `string` | `"ca.crt"` | no |
-| vault\_instance\_base\_image | Base operating system image in which to install Vault. This must be a Debian-based system at the moment due to how the metadata startup script runs. | `string` | `"debian-cloud/debian-10"` | no |
+| vault\_instance\_base\_image | Base operating system image in which to install Vault. This must be a Debian-based system at the moment due to how the metadata startup script runs. | `string` | `"debian-cloud/debian-11"` | no |
 | vault\_instance\_labels | Labels to apply to the Vault instances. | `map(string)` | `{}` | no |
 | vault\_instance\_metadata | Additional metadata to add to the Vault instances. | `map(string)` | `{}` | no |
 | vault\_instance\_tags | Additional tags to apply to the instances. Note 'allow-ssh' and 'allow-vault' will be present on all instances. | `list(string)` | `[]` | no |

--- a/modules/cluster/README.md
+++ b/modules/cluster/README.md
@@ -60,7 +60,7 @@ module "vault_cluster" {
 | user\_vault\_config | Additional user-provided vault config added at the end of standard vault config | `string` | `""` | no |
 | vault\_args | Additional command line arguments passed to Vault server | `string` | `""` | no |
 | vault\_ca\_cert\_filename | GCS object path within the vault\_tls\_bucket. This is the root CA certificate. | `string` | `"ca.crt"` | no |
-| vault\_instance\_base\_image | Base operating system image in which to install Vault. This must be a Debian-based system at the moment due to how the metadata startup script runs. | `string` | `"debian-cloud/debian-10"` | no |
+| vault\_instance\_base\_image | Base operating system image in which to install Vault. This must be a Debian-based system at the moment due to how the metadata startup script runs. | `string` | `"debian-cloud/debian-11"` | no |
 | vault\_instance\_labels | Labels to apply to the Vault instances. | `map(string)` | `{}` | no |
 | vault\_instance\_metadata | Additional metadata to add to the Vault instances. | `map(string)` | `{}` | no |
 | vault\_instance\_tags | Additional tags to apply to the instances. Note 'allow-ssh' and 'allow-vault' will be present on all instances. | `list(string)` | `[]` | no |

--- a/modules/cluster/variables.tf
+++ b/modules/cluster/variables.tf
@@ -156,7 +156,7 @@ variable "vault_instance_metadata" {
 
 variable "vault_instance_base_image" {
   type    = string
-  default = "debian-cloud/debian-10"
+  default = "debian-cloud/debian-11"
 
   description = "Base operating system image in which to install Vault. This must be a Debian-based system at the moment due to how the metadata startup script runs."
 }

--- a/variables.tf
+++ b/variables.tf
@@ -385,7 +385,7 @@ variable "vault_instance_metadata" {
 
 variable "vault_instance_base_image" {
   type    = string
-  default = "debian-cloud/debian-10"
+  default = "debian-cloud/debian-11"
 
   description = "Base operating system image in which to install Vault. This must be a Debian-based system at the moment due to how the metadata startup script runs."
 }


### PR DESCRIPTION
Update default image to `debian-cloud/debian-11` as `debian-cloud/debian-10` is no longer available.